### PR TITLE
Apply selected color to countdown cards

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -67,7 +67,10 @@ struct ContentView: View {
                                             title: item.title,
                                             daysLeft: days,
                                             dateText: dateText,
-                                            archived: item.isArchived
+                                            archived: item.isArchived,
+                                            backgroundStyle: item.backgroundStyle,
+                                            colorHex: item.backgroundColorHex,
+                                            imageData: item.backgroundImageData
                                         )
                                         .environmentObject(theme)
                                     }

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -7,19 +7,33 @@ struct CountdownCardView: View {
     let daysLeft: Int
     let dateText: String
     let archived: Bool
+    let backgroundStyle: String
+    let colorHex: String?
+    let imageData: Data?
 
     private let corner: CGFloat = 22
     private let height: CGFloat = 120
 
     var body: some View {
         ZStack(alignment: .leading) {
-            // Themed background (simple, sleek)
+            // Background color or image
             RoundedRectangle(cornerRadius: corner, style: .continuous)
-                .fill(LinearGradient(
-                    colors: [accent, accent.opacity(0.75)],
-                    startPoint: .topLeading, endPoint: .bottomTrailing
-                ))
-                .overlay(                         // tiny inner highlight
+                .fill(backgroundFill)
+                .overlay(
+                    Group {
+                        if let data = imageData,
+                           backgroundStyle == "image",
+                           let ui = UIImage(data: data) {
+                            Image(uiImage: ui)
+                                .resizable()
+                                .scaledToFill()
+                                .clipped()
+                                .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+                        }
+                    }
+                )
+                .overlay(
+                    // tiny inner highlight
                     RoundedRectangle(cornerRadius: corner, style: .continuous)
                         .stroke(.white.opacity(0.06), lineWidth: 1)
                 )
@@ -50,4 +64,21 @@ struct CountdownCardView: View {
     }
 
     private var accent: Color { theme.theme.accent }
+
+    private var backgroundFill: some ShapeStyle {
+        if backgroundStyle == "color",
+           let hex = colorHex,
+           let c = Color(hex: hex) {
+            return AnyShapeStyle(
+                LinearGradient(colors: [c, c.opacity(0.75)],
+                               startPoint: .topLeading,
+                               endPoint: .bottomTrailing)
+            )
+        }
+        return AnyShapeStyle(
+            LinearGradient(colors: [accent, accent.opacity(0.75)],
+                           startPoint: .topLeading,
+                           endPoint: .bottomTrailing)
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- render countdown cards using per-countdown background color or image
- pass background data from ContentView to CountdownCardView

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a623967ffc8333858d168e4beb3c59