### PR TITLE
Fix countdown card image clipping

### DIFF
--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -28,10 +28,10 @@ struct CountdownCardView: View {
                                 .resizable()
                                 .scaledToFill()
                                 .clipped()
-                                .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
                         }
                     }
                 )
+                .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
                 .overlay(
                     // tiny inner highlight
                     RoundedRectangle(cornerRadius: corner, style: .continuous)


### PR DESCRIPTION
## Summary
- ensure countdown card background images are clipped to card shape to prevent overflow

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project CouplesCount.xcodeproj -scheme CouplesCount -sdk iphonesimulator -quiet` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a64941127c8333977673e067185d2a