### PR TITLE
Add bottom tabs with profile view

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -3,6 +3,25 @@ import SwiftData
 
 struct ContentView: View {
     @EnvironmentObject private var theme: ThemeManager
+
+    var body: some View {
+        TabView {
+            CountdownListView()
+                .tabItem {
+                    Label("Countdowns", systemImage: "timer")
+                }
+
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person.crop.circle")
+                }
+        }
+        .tint(theme.theme.accent)
+    }
+}
+
+struct CountdownListView: View {
+    @EnvironmentObject private var theme: ThemeManager
     @Environment(\.modelContext) private var modelContext
 
     @Query(filter: #Predicate<Countdown> { !$0.isArchived },

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import SwiftData
+
+struct ProfileView: View {
+    @EnvironmentObject private var theme: ThemeManager
+    @Query(sort: \Countdown.targetDate, order: .forward)
+    private var shared: [Countdown]
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                // Header similar to Instagram
+                HStack {
+                    Circle()
+                        .fill(theme.theme.accent)
+                        .frame(width: 80, height: 80)
+                    Spacer()
+                    VStack {
+                        Text("\(shared.count)")
+                            .font(.headline)
+                        Text("Posts")
+                            .font(.subheadline)
+                    }
+                    Spacer()
+                    VStack {
+                        Text("0")
+                            .font(.headline)
+                        Text("Followers")
+                            .font(.subheadline)
+                    }
+                    Spacer()
+                    VStack {
+                        Text("0")
+                            .font(.headline)
+                        Text("Following")
+                            .font(.subheadline)
+                    }
+                }
+                .padding(.horizontal)
+
+                Text("Username")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal)
+                    .padding(.top, 4)
+
+                // Grid of shared countdowns
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 2), spacing: 8) {
+                    ForEach(shared) { item in
+                        let days = DateUtils.daysUntil(target: item.targetDate, in: item.timeZoneID)
+                        let dateText = DateUtils.readableDate.string(from: item.targetDate)
+                        CountdownCardView(
+                            title: item.title,
+                            daysLeft: days,
+                            dateText: dateText,
+                            archived: item.isArchived,
+                            backgroundStyle: item.backgroundStyle,
+                            colorHex: item.backgroundColorHex,
+                            imageData: item.backgroundImageData
+                        )
+                        .environmentObject(theme)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.top, 8)
+            }
+        }
+        .background(theme.theme.background.ignoresSafeArea())
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce tab-based navigation combining countdown list and new profile page
- Add Instagram-style profile view with header and grid of countdown cards
- Fix SwiftData query in profile view by specifying Countdown as key path root

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6669bf42c83338973fd36ebbea457