### PR TITLE
feat: add archive management and improved edit UI

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -102,11 +102,10 @@ struct CountdownListView: View {
                                     }
                                     .swipeActions(edge: .leading) {
                                         Button {
-                                            item.isArchived.toggle()
+                                            item.isArchived = true
                                             try? modelContext.save()
                                         } label: {
-                                            Label(item.isArchived ? "Unarchive" : "Archive",
-                                                  systemImage: item.isArchived ? "tray.and.arrow.up" : "archivebox")
+                                            Label("Archive", systemImage: "archivebox")
                                         }
                                         .tint(.blue)
                                     }

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -235,6 +235,17 @@ struct AddEditCountdownView: View {
 
                     if let existing {
                         SettingsCard {
+                            Button {
+                                existing.isArchived.toggle()
+                                try? modelContext.save()
+                                dismiss()
+                            } label: {
+                                Label(existing.isArchived ? "Unarchive Countdown" : "Archive Countdown",
+                                      systemImage: existing.isArchived ? "tray.and.arrow.up" : "archivebox")
+                            }
+                        }
+
+                        SettingsCard {
                             Button(role: .destructive) {
                                 NotificationManager.cancelAll(for: existing.id)
                                 modelContext.delete(existing)
@@ -245,27 +256,19 @@ struct AddEditCountdownView: View {
                             }
                         }
                     }
-
-                    // MARK: Big Save at bottom
-                    SettingsCard {
-                        Button(action: save) {
-                            Label("Save", systemImage: "checkmark.circle.fill")
-                                .font(.headline)
-                                .padding(.vertical, 12)
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(theme.theme.accent)
-                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    }
-                    .padding(.horizontal, 0)
-                    .padding(.bottom, 24)
                 }
                 .padding(.top, 14)
                 .padding(.horizontal, 16)
             }
+            .scrollIndicators(.hidden)
+            .overlay(alignment: .trailing) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.gray.opacity(0.4))
+                    .frame(width: 6)
+                    .padding(.vertical, 8)
+                    .padding(.trailing, 2)
+            }
             .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.accent)
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -273,9 +276,10 @@ struct AddEditCountdownView: View {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") { save() }
-                        .bold()
-                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    Button(action: save) {
+                        Image(systemName: "checkmark")
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             .sheet(isPresented: $showPhotoPicker) { PhotoPicker(imageData: $imageData) }


### PR DESCRIPTION
## Summary
- add archive/unarchive button in countdown editor
- make settings archive tab navigate to archive manager and drop appearance header
- redesign add/edit screen with persistent scroll bar and top-right save checkmark
- enable swipe left to delete and swipe right to archive countdown cards

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a675a020ac833393a90665d300fec8