### PR TITLE
feat: enable swipe actions and top save button

### DIFF
--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -67,9 +67,8 @@ struct AddEditCountdownView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack(alignment: .bottomTrailing) {
-                ScrollView {
-                    VStack(spacing: 18) {
+            ScrollView {
+                VStack(spacing: 18) {
 
                     // MARK: Swipable widget preview (square → rectangular)
                     TabView {
@@ -269,18 +268,6 @@ struct AddEditCountdownView: View {
                     .padding(.vertical, 8)
                     .padding(.trailing, 2)
             }
-
-                Button(action: save) {
-                    Image(systemName: "checkmark")
-                        .font(.title2)
-                        .padding(18)
-                        .background(Circle().fill(theme.theme.accent))
-                        .foregroundStyle(.white)
-                        .shadow(radius: 4, y: 2)
-                }
-                .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                .padding(24)
-            }
             .background(theme.theme.background.ignoresSafeArea())
             .tint(theme.theme.accent)
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
@@ -288,6 +275,12 @@ struct AddEditCountdownView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: save) {
+                        Image(systemName: "checkmark")
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             .sheet(isPresented: $showPhotoPicker) { PhotoPicker(imageData: $imageData) }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -13,6 +13,7 @@ struct ProfileView: View {
     @State private var showPhotoPicker = false
     @State private var showCameraPicker = false
     @State private var showPhotoOptions = false
+    @State private var deleteConfirm: Countdown? = nil
 
     var body: some View {
         ScrollView {
@@ -108,6 +109,22 @@ struct ProfileView: View {
                             shared: item.isShared
                         )
                         .environmentObject(theme)
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                deleteConfirm = item
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                item.isArchived = true
+                                try? modelContext.save()
+                            } label: {
+                                Label("Archive", systemImage: "archivebox")
+                            }
+                            .tint(.blue)
+                        }
                     }
                 }
                 .padding(.horizontal)
@@ -115,5 +132,22 @@ struct ProfileView: View {
             }
         }
         .background(theme.theme.background.ignoresSafeArea())
+        .confirmationDialog(
+            "Delete Countdown?",
+            isPresented: Binding(
+                get: { deleteConfirm != nil },
+                set: { if !$0 { deleteConfirm = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let item = deleteConfirm {
+                    modelContext.delete(item)
+                    try? modelContext.save()
+                }
+                deleteConfirm = nil
+            }
+            Button("Cancel", role: .cancel) { deleteConfirm = nil }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enable swipe-to-delete/archiving on profile countdown cards
- move save checkmark to the navigation bar in add/edit screen

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a67a2a36ac8333ba410553828d108b