### PR TITLE
feat: enable swipe gestures and top save button

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -78,38 +78,34 @@ struct CountdownListView: View {
                                     )
                                     let dateText = DateUtils.readableDate.string(from: item.targetDate)
 
-                                    Button {
+                                    CountdownCardView(
+                                        title: item.title,
+                                        daysLeft: days,
+                                        dateText: dateText,
+                                        archived: item.isArchived,
+                                        backgroundStyle: item.backgroundStyle,
+                                        colorHex: item.backgroundColorHex,
+                                        imageData: item.backgroundImageData,
+                                        shared: item.isShared
+                                    )
+                                    .environmentObject(theme)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
                                         editing = item
                                         showAddEdit = true
-                                    } label: {
-                                        CountdownCardView(
-                                            title: item.title,
-                                            daysLeft: days,
-                                            dateText: dateText,
-                                            archived: item.isArchived,
-                                            backgroundStyle: item.backgroundStyle,
-                                            colorHex: item.backgroundColorHex,
-                                            imageData: item.backgroundImageData,
-                                            shared: item.isShared
-                                        )
-                                        .environmentObject(theme)
                                     }
-                                    .buttonStyle(.plain)
-                                    .swipeActions(edge: .trailing) {
-                                        Button(role: .destructive) {
-                                            deleteConfirm = item
-                                        } label: { Label("Delete", systemImage: "trash") }
-                                    }
-                                    .swipeActions(edge: .leading) {
-                                        Button {
-                                            item.isArchived.toggle()
-                                            try? modelContext.save()
-                                        } label: {
-                                            Label(item.isArchived ? "Unarchive" : "Archive",
-                                                  systemImage: item.isArchived ? "tray.and.arrow.up" : "archivebox")
-                                        }
-                                        .tint(.blue)
-                                    }
+                                    .gesture(
+                                        DragGesture(minimumDistance: 30, coordinateSpace: .local)
+                                            .onEnded { value in
+                                                guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                                                if value.translation.width < -80 {
+                                                    deleteConfirm = item
+                                                } else if value.translation.width > 80 {
+                                                    item.isArchived.toggle()
+                                                    try? modelContext.save()
+                                                }
+                                            }
+                                    )
                                 }
                                 .padding(.horizontal) // nice side gutters
                                 .padding(.top, 12)

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -67,9 +67,8 @@ struct AddEditCountdownView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack(alignment: .bottomTrailing) {
-                ScrollView {
-                    VStack(spacing: 18) {
+            ScrollView {
+                VStack(spacing: 18) {
 
                     // MARK: Swipable widget preview (square → rectangular)
                     TabView {
@@ -269,18 +268,6 @@ struct AddEditCountdownView: View {
                     .padding(.vertical, 8)
                     .padding(.trailing, 2)
             }
-
-                Button(action: save) {
-                    Image(systemName: "checkmark")
-                        .font(.title2)
-                        .padding(18)
-                        .background(Circle().fill(theme.theme.accent))
-                        .foregroundStyle(.white)
-                        .shadow(radius: 4, y: 2)
-                }
-                .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                .padding(24)
-            }
             .background(theme.theme.background.ignoresSafeArea())
             .tint(theme.theme.accent)
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
@@ -288,6 +275,12 @@ struct AddEditCountdownView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: save) {
+                        Image(systemName: "checkmark")
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             .sheet(isPresented: $showPhotoPicker) { PhotoPicker(imageData: $imageData) }


### PR DESCRIPTION
## Summary
- enable swipe-to-delete/archiving on profile countdown cards using drag gestures
- move save checkmark to the navigation bar in add/edit screen
- add swipe actions to main countdown list for deleting or archiving via drag gestures

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a67a2a36ac8333ba410553828d108b