### PR TITLE
Fix swipe actions by using List or context menu

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -68,55 +68,54 @@ struct CountdownListView: View {
                         }
                         Spacer()
                     } else {
-                        ScrollView {
-                            LazyVStack(spacing: 16) {
-                                ForEach(items) { item in
-                                    // Compute per-item display values
-                                    let days = DateUtils.daysUntil(
-                                        target: item.targetDate,
-                                        in: item.timeZoneID
-                                    )
-                                    let dateText = DateUtils.readableDate.string(from: item.targetDate)
+                        List {
+                            ForEach(items) { item in
+                                // Compute per-item display values
+                                let days = DateUtils.daysUntil(
+                                    target: item.targetDate,
+                                    in: item.timeZoneID
+                                )
+                                let dateText = DateUtils.readableDate.string(from: item.targetDate)
 
-                                    CountdownCardView(
-                                        title: item.title,
-                                        daysLeft: days,
-                                        dateText: dateText,
-                                        archived: item.isArchived,
-                                        backgroundStyle: item.backgroundStyle,
-                                        colorHex: item.backgroundColorHex,
-                                        imageData: item.backgroundImageData,
-                                        shared: item.isShared
-                                    )
-                                    .environmentObject(theme)
-                                    .contentShape(Rectangle())
-                                    .onTapGesture {
-                                        editing = item
-                                        showAddEdit = true
-                                    }
-                                    .swipeActions(edge: .trailing) {
-                                        Button(role: .destructive) {
-                                            deleteConfirm = item
-                                        } label: {
-                                            Label("Delete", systemImage: "trash")
-                                        }
-                                    }
-                                    .swipeActions(edge: .leading) {
-                                        Button {
-                                            item.isArchived.toggle()
-                                            try? modelContext.save()
-                                        } label: {
-                                            Label(item.isArchived ? "Unarchive" : "Archive",
-                                                  systemImage: item.isArchived ? "tray.and.arrow.up" : "archivebox")
-                                        }
-                                        .tint(.blue)
+                                CountdownCardView(
+                                    title: item.title,
+                                    daysLeft: days,
+                                    dateText: dateText,
+                                    archived: item.isArchived,
+                                    backgroundStyle: item.backgroundStyle,
+                                    colorHex: item.backgroundColorHex,
+                                    imageData: item.backgroundImageData,
+                                    shared: item.isShared
+                                )
+                                .environmentObject(theme)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    editing = item
+                                    showAddEdit = true
+                                }
+                                .listRowSeparator(.hidden)
+                                .listRowInsets(.init(top: 0, leading: 16, bottom: 0, trailing: 16))
+                                .swipeActions(edge: .trailing) {
+                                    Button(role: .destructive) {
+                                        deleteConfirm = item
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
                                     }
                                 }
-                                .padding(.horizontal) // nice side gutters
-                                .padding(.top, 12)
+                                .swipeActions(edge: .leading) {
+                                    Button {
+                                        item.isArchived.toggle()
+                                        try? modelContext.save()
+                                    } label: {
+                                        Label(item.isArchived ? "Unarchive" : "Archive",
+                                              systemImage: item.isArchived ? "tray.and.arrow.up" : "archivebox")
+                                    }
+                                    .tint(.blue)
+                                }
                             }
                         }
-                        .scrollIndicators(.hidden)
+                        .listStyle(.plain)
+                        .padding(.top, 12)
                     }
                 }
 

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -109,21 +109,19 @@ struct ProfileView: View {
                             shared: item.isShared
                         )
                         .environmentObject(theme)
-                        .swipeActions(edge: .trailing) {
+                        .contextMenu {
                             Button(role: .destructive) {
                                 deleteConfirm = item
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
-                        }
-                        .swipeActions(edge: .leading) {
+
                             Button {
                                 item.isArchived = true
                                 try? modelContext.save()
                             } label: {
                                 Label("Archive", systemImage: "archivebox")
                             }
-                            .tint(.blue)
                         }
                     }
                 }

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -181,45 +181,44 @@ struct ArchiveView: View {
                             .foregroundStyle(.secondary)
                     }
                 } else {
-                    ScrollView {
-                        LazyVStack(spacing: 16) {
-                            ForEach(items) { item in
-                                let days = DateUtils.daysUntil(target: item.targetDate, in: item.timeZoneID)
-                                let dateText = DateUtils.readableDate.string(from: item.targetDate)
+                    List {
+                        ForEach(items) { item in
+                            let days = DateUtils.daysUntil(target: item.targetDate, in: item.timeZoneID)
+                            let dateText = DateUtils.readableDate.string(from: item.targetDate)
 
-                                CountdownCardView(
-                                    title: item.title,
-                                    daysLeft: days,
-                                    dateText: dateText,
-                                    archived: item.isArchived,
-                                    backgroundStyle: item.backgroundStyle,
-                                    colorHex: item.backgroundColorHex,
-                                    imageData: item.backgroundImageData,
-                                    shared: item.isShared
-                                )
-                                .environmentObject(theme)
-                                .swipeActions(edge: .trailing) {
-                                    Button(role: .destructive) {
-                                        deleteConfirm = item
-                                    } label: {
-                                        Label("Delete", systemImage: "trash")
-                                    }
-                                }
-                                .swipeActions(edge: .leading) {
-                                    Button {
-                                        item.isArchived = false
-                                        try? modelContext.save()
-                                    } label: {
-                                        Label("Unarchive", systemImage: "tray.and.arrow.up")
-                                    }
-                                    .tint(.blue)
+                            CountdownCardView(
+                                title: item.title,
+                                daysLeft: days,
+                                dateText: dateText,
+                                archived: item.isArchived,
+                                backgroundStyle: item.backgroundStyle,
+                                colorHex: item.backgroundColorHex,
+                                imageData: item.backgroundImageData,
+                                shared: item.isShared
+                            )
+                            .environmentObject(theme)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(.init(top: 0, leading: 16, bottom: 0, trailing: 16))
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    deleteConfirm = item
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
                                 }
                             }
-                            .padding(.horizontal)
-                            .padding(.top, 12)
+                            .swipeActions(edge: .leading) {
+                                Button {
+                                    item.isArchived = false
+                                    try? modelContext.save()
+                                } label: {
+                                    Label("Unarchive", systemImage: "tray.and.arrow.up")
+                                }
+                                .tint(.blue)
+                            }
                         }
                     }
-                    .scrollIndicators(.hidden)
+                    .listStyle(.plain)
+                    .padding(.top, 12)
                 }
             }
             .navigationTitle("Archive")


### PR DESCRIPTION
## Summary
- use `List` for countdown and archive screens so iOS swipe gestures work
- fall back to context menus for profile grid items

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a71307ccb483339cad0b3b3f339069