### PR TITLE
Simplify archive navigation and add premium promo animation

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -32,6 +32,7 @@ struct CountdownListView: View {
     @State private var editing: Countdown? = nil
     @State private var showSettings = false
     @State private var deleteConfirm: Countdown? = nil
+    @State private var showPremium = false
 
     var body: some View {
         NavigationStack {
@@ -41,7 +42,11 @@ struct CountdownListView: View {
                 VStack(spacing: 0) {
                     // Top bar
                     HStack {
-                        Button { /* premium placeholder */ } label: {
+                        Button {
+                            withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                                showPremium = true
+                            }
+                        } label: {
                             Image(systemName: "crown.fill").font(.title2)
                         }
                         Spacer()
@@ -140,6 +145,14 @@ struct CountdownListView: View {
                     .padding(.bottom, 24)
                 }
                 .frame(maxWidth: .infinity) // centers horizontally
+            }
+            .overlay(alignment: .topLeading) {
+                if showPremium {
+                    PremiumPromoView(show: $showPremium)
+                        .environmentObject(theme)
+                        .transition(.scale(scale: 0.1, anchor: .topLeading).combined(with: .opacity))
+                        .zIndex(1)
+                }
             }
             .sheet(isPresented: $showAddEdit) {
                 AddEditCountdownView(existing: editing)

--- a/CouplesCount/Views/PremiumPromoView.swift
+++ b/CouplesCount/Views/PremiumPromoView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct PremiumPromoView: View {
+    @EnvironmentObject private var theme: ThemeManager
+    @Binding var show: Bool
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            theme.theme.background.ignoresSafeArea()
+
+            VStack {
+                Spacer()
+                Image(systemName: "crown.fill")
+                    .font(.system(size: 80))
+                    .foregroundStyle(theme.theme.accent)
+                Text("CouplesCount Premium")
+                    .font(.largeTitle.bold())
+                    .padding(.top, 12)
+                Text("Unlock exclusive features and themes.")
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .padding()
+                Spacer()
+            }
+
+            Button {
+                withAnimation(.spring()) { show = false }
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title2)
+                    .padding()
+            }
+        }
+    }
+}

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -222,8 +222,11 @@ struct ArchiveView: View {
                 }
             }
             .navigationTitle("Archive")
+            .navigationBarBackButtonHidden(true)
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
             }
             .confirmationDialog(
                 "Delete Countdown?",


### PR DESCRIPTION
## Summary
- Replace archive screen's cluttered toolbar with a simple "Back" button
- Add a premium crown button animation that opens a minimalist promo view
- Introduce dedicated `PremiumPromoView` for showcasing premium features

## Testing
- ⚠️ `swift build` *(Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a71a7937d0833393964d7ab228575e