### PR TITLE
Revamp settings navigation and rating flow

### DIFF
--- a/CouplesCount/Views/FeedbackFormView.swift
+++ b/CouplesCount/Views/FeedbackFormView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct FeedbackFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var theme: ThemeManager
+
+    @State private var rating: Int = 3
+    @State private var message: String = ""
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("How can we improve?")
+                    .font(.headline)
+
+                HStack {
+                    ForEach(1...5, id: \.self) { index in
+                        Image(systemName: index <= rating ? "star.fill" : "star")
+                            .font(.title)
+                            .foregroundStyle(.yellow)
+                            .onTapGesture { rating = index }
+                    }
+                }
+                .padding(.vertical)
+
+                TextEditor(text: $message)
+                    .frame(height: 120)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(.secondary.opacity(0.2))
+                    )
+
+                Button("Submit") {
+                    // TODO: Send feedback to backend
+                    print("Feedback rating: \(rating), message: \(message)")
+                    dismiss()
+                }
+                .frame(maxWidth: .infinity)
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+            .navigationTitle("Feedback")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .tint(theme.theme.accent)
+    }
+}
+

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -11,6 +11,8 @@ struct SettingsView: View {
     private let themes: [ColorTheme] = [.light, .dark, .royalBlues, .barbie, .lucky]
     private let supportEmail = "support@couplescount.app"
     @State private var activeAlert: ActiveAlert?
+    @State private var showEnjoyPrompt = false
+    @State private var showFeedbackForm = false
 
     var body: some View {
         NavigationStack {
@@ -57,10 +59,8 @@ struct SettingsView: View {
                                 Text("Manage Archive")
                                     .font(.body)
                                 Spacer()
-                                Image(systemName: "chevron.right")
-                                    .font(.footnote.weight(.semibold))
-                                    .foregroundStyle(theme.theme.accent)
                             }
+                            .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                     }
@@ -75,10 +75,7 @@ struct SettingsView: View {
                         }
                         Divider().opacity(0.1)
                         buttonRow(icon: "star.fill", title: "Rate CouplesCount") {
-                            if let scene = UIApplication.shared.connectedScenes
-                                .first as? UIWindowScene {
-                                SKStoreReviewController.requestReview(in: scene)
-                            }
+                            showEnjoyPrompt = true
                         }
                     }
 
@@ -118,6 +115,23 @@ struct SettingsView: View {
                 )
             }
         }
+        .confirmationDialog(
+            "Are you enjoying the app so far?",
+            isPresented: $showEnjoyPrompt,
+            titleVisibility: .visible
+        ) {
+            Button("Yes") {
+                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                    SKStoreReviewController.requestReview(in: scene)
+                }
+            }
+            Button("No") { showFeedbackForm = true }
+            Button("Cancel", role: .cancel) {}
+        }
+        .sheet(isPresented: $showFeedbackForm) {
+            FeedbackFormView()
+                .environmentObject(theme)
+        }
     }
 
     // MARK: - Row helpers
@@ -139,10 +153,8 @@ struct SettingsView: View {
                     )
                 Text(title).font(.body)
                 Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(theme.theme.accent)
             }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
## Summary
- Remove chevron indicators and make settings rows fully tappable
- Add rating prompt that opens App Store reviews or an in-app feedback form
- Introduce feedback form mimicking Apple's review sheet

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a71e1407cc8333929f3c5916c8ce94