### PR TITLE
Improve feedback form and theme visibility

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -73,14 +73,14 @@ struct CountdownListView: View {
                         }
                         Spacer()
                     } else {
-                        List {
-                            ForEach(items) { item in
-                                // Compute per-item display values
-                                let days = DateUtils.daysUntil(
-                                    target: item.targetDate,
-                                    in: item.timeZoneID
-                                )
-                                let dateText = DateUtils.readableDate.string(from: item.targetDate)
+                          List {
+                              ForEach(items) { item in
+                                  // Compute per-item display values
+                                  let days = DateUtils.daysUntil(
+                                      target: item.targetDate,
+                                      in: item.timeZoneID
+                                  )
+                                  let dateText = DateUtils.readableDate.string(from: item.targetDate)
 
                                 CountdownCardView(
                                     title: item.title,
@@ -98,13 +98,14 @@ struct CountdownListView: View {
                                     editing = item
                                     showAddEdit = true
                                 }
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
-                                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                                    Button(role: .destructive) {
-                                        deleteConfirm = item
-                                    } label: {
-                                        Label("Delete", systemImage: "trash")
+                                  .listRowSeparator(.hidden)
+                                  .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
+                                  .listRowBackground(theme.theme.background)
+                                  .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                      Button(role: .destructive) {
+                                          deleteConfirm = item
+                                      } label: {
+                                          Label("Delete", systemImage: "trash")
                                     }
                                 }
                                 .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -121,11 +122,12 @@ struct CountdownListView: View {
                                 }
                             }
                         }
-                        .listStyle(.plain)
-                        .listRowSpacing(16)
-                        .padding(.top, 28)
-                        .animation(.easeInOut, value: items)
-                    }
+                          .listStyle(.plain)
+                          .listRowSpacing(16)
+                          .padding(.top, 28)
+                          .scrollContentBackground(.hidden)
+                          .animation(.easeInOut, value: items)
+                      }
                 }
 
                 // Centered bottom +

--- a/CouplesCount/Views/FeedbackFormView.swift
+++ b/CouplesCount/Views/FeedbackFormView.swift
@@ -10,8 +10,16 @@ struct FeedbackFormView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
-                Text("How can we improve?")
+                Text("I'm a solo dev and every review means a lot. I read every suggestion, so please let me know how I can improve.")
                     .font(.headline)
+                    .multilineTextAlignment(.center)
+
+                TextEditor(text: $message)
+                    .frame(height: 120)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(.secondary.opacity(0.2))
+                    )
 
                 HStack {
                     ForEach(1...5, id: \.self) { index in
@@ -23,19 +31,13 @@ struct FeedbackFormView: View {
                 }
                 .padding(.vertical)
 
-                TextEditor(text: $message)
-                    .frame(height: 120)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(.secondary.opacity(0.2))
-                    )
-
                 Button("Submit") {
                     // TODO: Send feedback to backend
                     print("Feedback rating: \(rating), message: \(message)")
                     dismiss()
                 }
                 .frame(maxWidth: .infinity)
+                .controlSize(.large)
                 .buttonStyle(.borderedProminent)
             }
             .padding()

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -47,19 +47,19 @@ struct SettingsView: View {
                             ArchiveView()
                                 .environmentObject(theme)
                         } label: {
-                            HStack(spacing: 12) {
-                                Image(systemName: "archivebox.fill")
-                                    .font(.title3)
-                                    .foregroundStyle(.white)
-                                    .frame(width: 30, height: 30)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 8)
-                                            .fill(theme.theme.accent)
-                                    )
-                                Text("Manage Archive")
-                                    .font(.body)
-                                Spacer()
-                            }
+                              HStack(spacing: 12) {
+                                  Image(systemName: "archivebox.fill")
+                                      .font(.title3)
+                                      .foregroundStyle(theme.theme.background)
+                                      .frame(width: 30, height: 30)
+                                      .background(
+                                          RoundedRectangle(cornerRadius: 8)
+                                              .fill(theme.theme.accent)
+                                      )
+                                  Text("Manage Archive")
+                                      .font(.body)
+                                  Spacer()
+                              }
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
@@ -145,7 +145,7 @@ struct SettingsView: View {
             HStack(spacing: 12) {
                 Image(systemName: icon)
                     .font(.title3)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(theme.theme.background)
                     .frame(width: 30, height: 30)
                     .background(
                         RoundedRectangle(cornerRadius: 8)


### PR DESCRIPTION
## Summary
- rearrange feedback form so comments sit above rating with larger submit button and heartfelt message
- ensure settings icons remain visible across all color themes
- smooth swipe reveal on countdown list to remove side-wall artifacts

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a7208d03bc83338da9d81786159d41