### PR TITLE
Improve swipe actions and delete button visibility

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -31,7 +31,6 @@ struct CountdownListView: View {
     @State private var showAddEdit = false
     @State private var editing: Countdown? = nil
     @State private var showSettings = false
-    @State private var deleteConfirm: Countdown? = nil
     @State private var showPremium = false
 
     var body: some View {
@@ -101,25 +100,36 @@ struct CountdownListView: View {
                                   .listRowSeparator(.hidden)
                                   .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
                                   .listRowBackground(theme.theme.background)
-                                  .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                                      Button(role: .destructive) {
-                                          deleteConfirm = item
+                                  .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                      Button {
+                                          withAnimation(.easeInOut) {
+                                              modelContext.delete(item)
+                                              try? modelContext.save()
+                                          }
                                       } label: {
-                                          Label("Delete", systemImage: "trash")
-                                    }
-                                }
-                                .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                                    Button {
-                                        withAnimation(.easeInOut) {
-                                            item.isArchived.toggle()
-                                            try? modelContext.save()
-                                        }
-                                    } label: {
-                                        Label(item.isArchived ? "Unarchive" : "Archive",
-                                              systemImage: item.isArchived ? "tray.and.arrow.up" : "archivebox")
-                                    }
-                                    .tint(.blue)
-                                }
+                                          Text("Delete")
+                                              .font(.caption)
+                                              .padding(10)
+                                              .background(Circle().fill(Color.red))
+                                              .foregroundColor(.white)
+                                      }
+                                      .buttonStyle(.plain)
+                                  }
+                                  .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                      Button {
+                                          withAnimation(.easeInOut) {
+                                              item.isArchived.toggle()
+                                              try? modelContext.save()
+                                          }
+                                      } label: {
+                                          Text(item.isArchived ? "Unarchive" : "Archive")
+                                              .font(.caption)
+                                              .padding(10)
+                                              .background(Circle().fill(Color.blue))
+                                              .foregroundColor(.white)
+                                      }
+                                      .buttonStyle(.plain)
+                                  }
                             }
                         }
                           .listStyle(.plain)
@@ -162,25 +172,6 @@ struct CountdownListView: View {
             }
             .sheet(isPresented: $showSettings) {
                 SettingsView().environmentObject(theme)
-            }
-            .confirmationDialog(
-                "Delete Countdown?",
-                isPresented: Binding(
-                    get: { deleteConfirm != nil },
-                    set: { if !$0 { deleteConfirm = nil } }
-                ),
-                titleVisibility: .visible
-            ) {
-                Button("Delete", role: .destructive) {
-                    if let item = deleteConfirm {
-                        withAnimation(.easeInOut) {
-                            modelContext.delete(item)
-                            try? modelContext.save()
-                        }
-                    }
-                    deleteConfirm = nil
-                }
-                Button("Cancel", role: .cancel) { deleteConfirm = nil }
             }
         }
         .tint(theme.theme.accent)

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -13,7 +13,6 @@ struct ProfileView: View {
     @State private var showPhotoPicker = false
     @State private var showCameraPicker = false
     @State private var showPhotoOptions = false
-    @State private var deleteConfirm: Countdown? = nil
 
     var body: some View {
         ScrollView {
@@ -111,10 +110,12 @@ struct ProfileView: View {
                         .environmentObject(theme)
                         .contextMenu {
                             Button(role: .destructive) {
-                                deleteConfirm = item
+                                modelContext.delete(item)
+                                try? modelContext.save()
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
+                            .tint(.red)
 
                             Button {
                                 item.isArchived = true
@@ -130,22 +131,5 @@ struct ProfileView: View {
             }
         }
         .background(theme.theme.background.ignoresSafeArea())
-        .confirmationDialog(
-            "Delete Countdown?",
-            isPresented: Binding(
-                get: { deleteConfirm != nil },
-                set: { if !$0 { deleteConfirm = nil } }
-            ),
-            titleVisibility: .visible
-        ) {
-            Button("Delete", role: .destructive) {
-                if let item = deleteConfirm {
-                    modelContext.delete(item)
-                    try? modelContext.save()
-                }
-                deleteConfirm = nil
-            }
-            Button("Cancel", role: .cancel) { deleteConfirm = nil }
-        }
     }
 }

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -179,8 +179,6 @@ struct ArchiveView: View {
            sort: \Countdown.targetDate, order: .forward)
     private var items: [Countdown]
 
-    @State private var deleteConfirm: Countdown? = nil
-
     var body: some View {
         NavigationStack {
             ZStack {
@@ -211,21 +209,31 @@ struct ArchiveView: View {
                             .environmentObject(theme)
                             .listRowSeparator(.hidden)
                             .listRowInsets(.init(top: 0, leading: 16, bottom: 0, trailing: 16))
-                            .swipeActions(edge: .trailing) {
-                                Button(role: .destructive) {
-                                    deleteConfirm = item
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button {
+                                    modelContext.delete(item)
+                                    try? modelContext.save()
                                 } label: {
-                                    Label("Delete", systemImage: "trash")
+                                    Text("Delete")
+                                        .font(.caption)
+                                        .padding(10)
+                                        .background(Circle().fill(Color.red))
+                                        .foregroundColor(.white)
                                 }
+                                .buttonStyle(.plain)
                             }
-                            .swipeActions(edge: .leading) {
+                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                 Button {
                                     item.isArchived = false
                                     try? modelContext.save()
                                 } label: {
-                                    Label("Unarchive", systemImage: "tray.and.arrow.up")
+                                    Text("Unarchive")
+                                        .font(.caption)
+                                        .padding(10)
+                                        .background(Circle().fill(Color.blue))
+                                        .foregroundColor(.white)
                                 }
-                                .tint(.blue)
+                                .buttonStyle(.plain)
                             }
                         }
                     }
@@ -239,22 +247,6 @@ struct ArchiveView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Back") { dismiss() }
                 }
-            }
-            .confirmationDialog(
-                "Delete Countdown?",
-                isPresented: Binding(
-                    get: { deleteConfirm != nil },
-                    set: { if !$0 { deleteConfirm = nil } }
-                )
-            ) {
-                Button("Delete", role: .destructive) {
-                    if let item = deleteConfirm {
-                        modelContext.delete(item)
-                        try? modelContext.save()
-                    }
-                    deleteConfirm = nil
-                }
-                Button("Cancel", role: .cancel) { deleteConfirm = nil }
             }
         }
         .tint(theme.theme.accent)


### PR DESCRIPTION
## Summary
- Show red delete buttons regardless of theme
- Replace full-swipe archive/delete with circular buttons requiring tap
- Remove extra delete confirmation dialogs

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a7229871ac8333a5435f2833487105