### PR TITLE
Add swipe icons for delete and archive actions

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -107,11 +107,11 @@ struct CountdownListView: View {
                                               try? modelContext.save()
                                           }
                                       } label: {
-                                          Text("Delete")
-                                              .font(.caption)
-                                              .padding(10)
+                                          Image(systemName: "trash")
+                                              .font(.system(size: 16, weight: .bold))
+                                              .padding(12)
                                               .background(Circle().fill(Color.red))
-                                              .foregroundColor(.white)
+                                              .foregroundStyle(.white)
                                       }
                                       .buttonStyle(.plain)
                                   }
@@ -122,11 +122,11 @@ struct CountdownListView: View {
                                               try? modelContext.save()
                                           }
                                       } label: {
-                                          Text(item.isArchived ? "Unarchive" : "Archive")
-                                              .font(.caption)
-                                              .padding(10)
+                                          Image(systemName: item.isArchived ? "arrow.uturn.backward" : "archivebox")
+                                              .font(.system(size: 16, weight: .bold))
+                                              .padding(12)
                                               .background(Circle().fill(Color.blue))
-                                              .foregroundColor(.white)
+                                              .foregroundStyle(.white)
                                       }
                                       .buttonStyle(.plain)
                                   }

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -214,11 +214,11 @@ struct ArchiveView: View {
                                     modelContext.delete(item)
                                     try? modelContext.save()
                                 } label: {
-                                    Text("Delete")
-                                        .font(.caption)
-                                        .padding(10)
+                                    Image(systemName: "trash")
+                                        .font(.system(size: 16, weight: .bold))
+                                        .padding(12)
                                         .background(Circle().fill(Color.red))
-                                        .foregroundColor(.white)
+                                        .foregroundStyle(.white)
                                 }
                                 .buttonStyle(.plain)
                             }
@@ -227,11 +227,11 @@ struct ArchiveView: View {
                                     item.isArchived = false
                                     try? modelContext.save()
                                 } label: {
-                                    Text("Unarchive")
-                                        .font(.caption)
-                                        .padding(10)
+                                    Image(systemName: "arrow.uturn.backward")
+                                        .font(.system(size: 16, weight: .bold))
+                                        .padding(12)
                                         .background(Circle().fill(Color.blue))
-                                        .foregroundColor(.white)
+                                        .foregroundStyle(.white)
                                 }
                                 .buttonStyle(.plain)
                             }


### PR DESCRIPTION
## Summary
- Use icon-only circular buttons for delete and archive swipe actions
- Apply the same icon swipe actions in archive management view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a7465af2c48333885ef74d3250b4e6