### PR TITLE
Add swipe gestures with circular archive/delete buttons

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -107,13 +107,13 @@ struct CountdownListView: View {
                                               try? modelContext.save()
                                           }
                                       } label: {
-                                          Text("Delete")
-                                              .font(.caption)
-                                              .padding(10)
+                                          Image(systemName: "trash")
+                                              .font(.system(size: 16, weight: .bold))
+                                              .padding(12)
                                               .background(Circle().fill(Color.red))
-                                              .foregroundColor(.white)
+                                              .foregroundStyle(.white)
                                       }
-                                      .buttonStyle(.plain)
+                                      .tint(.clear)
                                   }
                                   .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                       Button {
@@ -122,13 +122,13 @@ struct CountdownListView: View {
                                               try? modelContext.save()
                                           }
                                       } label: {
-                                          Text(item.isArchived ? "Unarchive" : "Archive")
-                                              .font(.caption)
-                                              .padding(10)
+                                          Image(systemName: item.isArchived ? "arrow.uturn.backward" : "archivebox")
+                                              .font(.system(size: 16, weight: .bold))
+                                              .padding(12)
                                               .background(Circle().fill(Color.blue))
-                                              .foregroundColor(.white)
+                                              .foregroundStyle(.white)
                                       }
-                                      .buttonStyle(.plain)
+                                      .tint(.clear)
                                   }
                             }
                         }

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -214,26 +214,26 @@ struct ArchiveView: View {
                                     modelContext.delete(item)
                                     try? modelContext.save()
                                 } label: {
-                                    Text("Delete")
-                                        .font(.caption)
-                                        .padding(10)
+                                    Image(systemName: "trash")
+                                        .font(.system(size: 16, weight: .bold))
+                                        .padding(12)
                                         .background(Circle().fill(Color.red))
-                                        .foregroundColor(.white)
+                                        .foregroundStyle(.white)
                                 }
-                                .buttonStyle(.plain)
+                                .tint(.clear)
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                 Button {
                                     item.isArchived = false
                                     try? modelContext.save()
                                 } label: {
-                                    Text("Unarchive")
-                                        .font(.caption)
-                                        .padding(10)
+                                    Image(systemName: "arrow.uturn.backward")
+                                        .font(.system(size: 16, weight: .bold))
+                                        .padding(12)
                                         .background(Circle().fill(Color.blue))
-                                        .foregroundColor(.white)
+                                        .foregroundStyle(.white)
                                 }
-                                .buttonStyle(.plain)
+                                .tint(.clear)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Enable swipe gestures on countdown cards to archive or delete items
- Use circular icon buttons revealed on swipe for both main and archive lists

## Testing
- `xcodebuild -scheme CouplesCount -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14" build` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68a7465af2c48333885ef74d3250b4e6