### PR TITLE
Add countdown sharing via deep links

### DIFF
--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -276,11 +276,18 @@ struct AddEditCountdownView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(action: save) {
-                        Image(systemName: "checkmark")
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    HStack {
+                        if let existing, let url = CountdownShareService.exportURL(for: existing) {
+                            ShareLink(item: url) {
+                                Image(systemName: "square.and.arrow.up")
+                            }
+                        }
+                        Button(action: save) {
+                            Image(systemName: "checkmark")
+                        }
+                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
-                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             .sheet(isPresented: $showPhotoPicker) { PhotoPicker(imageData: $imageData) }

--- a/Services/CountdownShareService.swift
+++ b/Services/CountdownShareService.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftData
+
+struct CountdownShareData: Codable {
+    let title: String
+    let targetDate: Date
+    let timeZoneID: String
+    let backgroundStyle: String
+    let backgroundColorHex: String?
+    let backgroundImageData: Data?
+}
+
+enum CountdownShareError: LocalizedError {
+    case invalidURL
+    case decodeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Link is invalid."
+        case .decodeFailed: return "Could not decode countdown."
+        }
+    }
+}
+
+enum CountdownShareService {
+    static func exportURL(for countdown: Countdown) -> URL? {
+        let payload = CountdownShareData(
+            title: countdown.title,
+            targetDate: countdown.targetDate,
+            timeZoneID: countdown.timeZoneID,
+            backgroundStyle: countdown.backgroundStyle,
+            backgroundColorHex: countdown.backgroundColorHex,
+            backgroundImageData: countdown.backgroundImageData
+        )
+        guard let json = try? JSONEncoder().encode(payload) else { return nil }
+        let base64 = json.base64EncodedString()
+        guard let escaped = base64.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return nil }
+        return URL(string: "couplescount://import?data=\(escaped)")
+    }
+
+    static func importCountdown(from url: URL, context: ModelContext) throws {
+        guard
+            url.scheme == "couplescount",
+            url.host == "import",
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let dataItem = components.queryItems?.first(where: { $0.name == "data" })?.value,
+            let decodedBase64 = dataItem.removingPercentEncoding,
+            let data = Data(base64Encoded: decodedBase64)
+        else { throw CountdownShareError.invalidURL }
+
+        guard let payload = try? JSONDecoder().decode(CountdownShareData.self, from: data) else {
+            throw CountdownShareError.decodeFailed
+        }
+
+        let cd = Countdown(
+            title: payload.title,
+            targetDate: payload.targetDate,
+            timeZoneID: payload.timeZoneID,
+            backgroundStyle: payload.backgroundStyle,
+            backgroundColorHex: payload.backgroundColorHex,
+            backgroundImageData: payload.backgroundImageData
+        )
+        context.insert(cd)
+        try context.save()
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement CountdownShareService for encoding/decoding countdowns into deep-link URLs
- add ShareLink to Add/Edit view and countdown list context menu
- handle couplescount://import links by saving decoded countdowns into SwiftData

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme CouplesCount -destination 'generic/platform=iOS Simulator' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a861e083fc8333b6e932f37bf121df