### PR TITLE
Add countdown sharing via deep links

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 struct ContentView: View {
     @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.modelContext) private var modelContext
+    @State private var importError: String?
 
     var body: some View {
         TabView {
@@ -17,6 +19,18 @@ struct ContentView: View {
                 }
         }
         .tint(theme.theme.accent)
+        .onOpenURL { url in
+            do {
+                try CountdownShareService.importCountdown(from: url, context: modelContext)
+            } catch {
+                importError = error.localizedDescription
+            }
+        }
+        .alert("Import Failed", isPresented: Binding(get: { importError != nil }, set: { if !$0 { importError = nil } })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(importError ?? "")
+        }
     }
 }
 
@@ -89,7 +103,8 @@ struct CountdownListView: View {
                                     backgroundStyle: item.backgroundStyle,
                                     colorHex: item.backgroundColorHex,
                                     imageData: item.backgroundImageData,
-                                    shared: item.isShared
+                                    shared: item.isShared,
+                                    shareURL: CountdownShareService.exportURL(for: item)
                                 )
                                 .environmentObject(theme)
                                 .contentShape(Rectangle())

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -276,11 +276,18 @@ struct AddEditCountdownView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(action: save) {
-                        Image(systemName: "checkmark")
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    HStack {
+                        if let existing, let url = CountdownShareService.exportURL(for: existing) {
+                            ShareLink(item: url) {
+                                Image(systemName: "square.and.arrow.up")
+                            }
+                        }
+                        Button(action: save) {
+                            Image(systemName: "checkmark")
+                        }
+                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
-                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             .sheet(isPresented: $showPhotoPicker) { PhotoPicker(imageData: $imageData) }

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -11,6 +11,7 @@ struct CountdownCardView: View {
     let colorHex: String?
     let imageData: Data?
     let shared: Bool
+    let shareURL: URL?
 
     private let corner: CGFloat = 22
     private let height: CGFloat = 120
@@ -55,17 +56,20 @@ struct CountdownCardView: View {
             }
             .padding(18)
             .foregroundStyle(.white)
-            if shared {
-                VStack {
-                    HStack {
-                        Spacer()
-                        Image(systemName: "person.2.fill")
-                            .foregroundStyle(.white)
-                            .padding(8)
+        }
+        .overlay(alignment: .topTrailing) {
+            HStack(spacing: 4) {
+                if shared {
+                    Image(systemName: "person.2.fill")
+                }
+                if let url = shareURL {
+                    ShareLink(item: url) {
+                        Image(systemName: "square.and.arrow.up")
                     }
-                    Spacer()
                 }
             }
+            .padding(8)
+            .foregroundStyle(.white)
         }
         .frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
         .saturation(archived ? 0 : 1)

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -105,7 +105,8 @@ struct ProfileView: View {
                             backgroundStyle: item.backgroundStyle,
                             colorHex: item.backgroundColorHex,
                             imageData: item.backgroundImageData,
-                            shared: item.isShared
+                            shared: item.isShared,
+                            shareURL: nil
                         )
                         .environmentObject(theme)
                         .contextMenu {

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -196,16 +196,17 @@ struct ArchiveView: View {
                             let days = DateUtils.daysUntil(target: item.targetDate, in: item.timeZoneID)
                             let dateText = DateUtils.readableDate.string(from: item.targetDate)
 
-                            CountdownCardView(
-                                title: item.title,
-                                daysLeft: days,
-                                dateText: dateText,
-                                archived: item.isArchived,
-                                backgroundStyle: item.backgroundStyle,
-                                colorHex: item.backgroundColorHex,
-                                imageData: item.backgroundImageData,
-                                shared: item.isShared
-                            )
+                                CountdownCardView(
+                                    title: item.title,
+                                    daysLeft: days,
+                                    dateText: dateText,
+                                    archived: item.isArchived,
+                                    backgroundStyle: item.backgroundStyle,
+                                    colorHex: item.backgroundColorHex,
+                                    imageData: item.backgroundImageData,
+                                    shared: item.isShared,
+                                    shareURL: nil
+                                )
                             .environmentObject(theme)
                             .listRowSeparator(.hidden)
                             .listRowInsets(.init(top: 0, leading: 16, bottom: 0, trailing: 16))

--- a/Services/CountdownShareService.swift
+++ b/Services/CountdownShareService.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftData
+
+struct CountdownShareData: Codable {
+    let title: String
+    let targetDate: Date
+    let timeZoneID: String
+    let backgroundStyle: String
+    let backgroundColorHex: String?
+    let backgroundImageData: Data?
+}
+
+enum CountdownShareError: LocalizedError {
+    case invalidURL
+    case decodeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Link is invalid."
+        case .decodeFailed: return "Could not decode countdown."
+        }
+    }
+}
+
+enum CountdownShareService {
+    static func exportURL(for countdown: Countdown) -> URL? {
+        let payload = CountdownShareData(
+            title: countdown.title,
+            targetDate: countdown.targetDate,
+            timeZoneID: countdown.timeZoneID,
+            backgroundStyle: countdown.backgroundStyle,
+            backgroundColorHex: countdown.backgroundColorHex,
+            backgroundImageData: countdown.backgroundImageData
+        )
+        guard let json = try? JSONEncoder().encode(payload) else { return nil }
+        let base64 = json.base64EncodedString()
+        guard let escaped = base64.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return nil }
+        return URL(string: "couplescount://import?data=\(escaped)")
+    }
+
+    static func importCountdown(from url: URL, context: ModelContext) throws {
+        guard
+            url.scheme == "couplescount",
+            url.host == "import",
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let dataItem = components.queryItems?.first(where: { $0.name == "data" })?.value,
+            let decodedBase64 = dataItem.removingPercentEncoding,
+            let data = Data(base64Encoded: decodedBase64)
+        else { throw CountdownShareError.invalidURL }
+
+        guard let payload = try? JSONDecoder().decode(CountdownShareData.self, from: data) else {
+            throw CountdownShareError.decodeFailed
+        }
+
+        let cd = Countdown(
+            title: payload.title,
+            targetDate: payload.targetDate,
+            timeZoneID: payload.timeZoneID,
+            backgroundStyle: payload.backgroundStyle,
+            backgroundColorHex: payload.backgroundColorHex,
+            backgroundImageData: payload.backgroundImageData
+        )
+        context.insert(cd)
+        try context.save()
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement CountdownShareService for encoding/decoding countdowns into deep-link URLs
- add ShareLink to Add/Edit view and a share button on each countdown card
- handle couplescount://import links by saving decoded countdowns into SwiftData

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -scheme CouplesCount -destination 'generic/platform=iOS Simulator' build` *(fails: command not found: xcodebuild)*


------
https://chatgpt.com/codex/tasks/task_e_68a861e083fc8333b6e932f37bf121df