### PR TITLE
Fix share button and remove long-press share menu

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -115,13 +115,6 @@ struct CountdownListView: View {
                                 )
                                 .environmentObject(theme)
                                 .contentShape(Rectangle())
-                                .contextMenu {
-                                    if let url = CountdownShareService.exportURL(for: item) {
-                                        ShareLink(item: url) {
-                                            Label("Share", systemImage: "square.and.arrow.up")
-                                        }
-                                    }
-                                }
                                 .onTapGesture {
                                     editing = item
                                     showAddEdit = true
@@ -129,16 +122,6 @@ struct CountdownListView: View {
                                 .listRowSeparator(.hidden)
                                 .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
                                 .listRowBackground(theme.theme.background)
-                                .contextMenu {
-                                    if let exportURL {
-                                        Button {
-                                            shareURL = exportURL
-                                            showShareSheet = true
-                                        } label: {
-                                            Label("Share", systemImage: "square.and.arrow.up")
-                                        }
-                                    }
-                                }
                                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                     Button {
                                         withAnimation(.easeInOut) {

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -65,9 +65,14 @@ struct CountdownCardView: View {
                 }
                 if let shareAction {
                     Button(action: shareAction) {
-
                         Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 18, weight: .semibold))
+                            .padding(8)
+                            .background(
+                                Circle().fill(Color.white.opacity(0.25))
+                            )
                     }
+                    .buttonStyle(.plain)
                 }
             }
             .padding(8)


### PR DESCRIPTION
## Summary
- enlarge share button and make it respond to taps with system share sheet
- remove context menu triggers that required long press

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b4f42688333b3d66803b2b018a7