### PR TITLE
Compress countdown share URLs

### DIFF
--- a/Services/CountdownShareService.swift
+++ b/Services/CountdownShareService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftData
+import Compression
 
 struct CountdownShareData: Codable {
     let title: String
@@ -23,6 +24,10 @@ enum CountdownShareError: LocalizedError {
 }
 
 enum CountdownShareService {
+    /// Encodes a countdown into a compact shareable URL.
+    /// The payload is encoded as a binary property list, compressed,
+    /// then base64 encoded so the resulting link is much shorter than
+    /// the previous JSON-only approach.
     static func exportURL(for countdown: Countdown) -> URL? {
         let payload = CountdownShareData(
             title: countdown.title,
@@ -32,23 +37,37 @@ enum CountdownShareService {
             backgroundColorHex: countdown.backgroundColorHex,
             backgroundImageData: countdown.backgroundImageData
         )
-        guard let json = try? JSONEncoder().encode(payload) else { return nil }
-        let base64 = json.base64EncodedString()
-        guard let escaped = base64.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return nil }
-        return URL(string: "couplescount://import?data=\(escaped)")
+
+        // Encode using a binary property list to avoid the inherent base64
+        // expansion that JSON introduces for `Data` properties.
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        guard
+            let plist = try? encoder.encode(payload),
+            let compressed = try? plist.compressed(using: COMPRESSION_LZFSE)
+        else { return nil }
+
+        let base64 = compressed.base64EncodedString()
+        var components = URLComponents()
+        components.scheme = "couplescount"
+        components.host = "import"
+        components.queryItems = [URLQueryItem(name: "data", value: base64)]
+        return components.url
     }
 
+    /// Imports a countdown from a previously generated share URL.
     static func importCountdown(from url: URL, context: ModelContext) throws {
         guard
             url.scheme == "couplescount",
             url.host == "import",
             let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
             let dataItem = components.queryItems?.first(where: { $0.name == "data" })?.value,
-            let decodedBase64 = dataItem.removingPercentEncoding,
-            let data = Data(base64Encoded: decodedBase64)
+            let data = Data(base64Encoded: dataItem),
+            let decompressed = try? data.decompressed(using: COMPRESSION_LZFSE)
         else { throw CountdownShareError.invalidURL }
 
-        guard let payload = try? JSONDecoder().decode(CountdownShareData.self, from: data) else {
+        let decoder = PropertyListDecoder()
+        guard let payload = try? decoder.decode(CountdownShareData.self, from: decompressed) else {
             throw CountdownShareError.decodeFailed
         }
 

--- a/Shared/Utilities/DataCompression.swift
+++ b/Shared/Utilities/DataCompression.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Compression
+
+/// Errors that can occur while compressing or decompressing `Data` values.
+enum DataCompressionError: Error {
+    case compressionFailed
+    case decompressionFailed
+}
+
+extension Data {
+    /// Returns a compressed representation of the data using the specified
+    /// algorithm. The output buffer grows automatically if the initial
+    /// capacity is insufficient.
+    func compressed(using algorithm: compression_algorithm) throws -> Data {
+        guard !isEmpty else { return self }
+
+        return try withUnsafeBytes { (srcBuffer: UnsafeRawBufferPointer) -> Data in
+            guard let srcPtr = srcBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                throw DataCompressionError.compressionFailed
+            }
+
+            var dstSize = Swift.max(count, 64)
+            var dstBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: dstSize)
+            var outputSize = compression_encode_buffer(
+                dstBuffer,
+                dstSize,
+                srcPtr,
+                count,
+                nil,
+                algorithm
+            )
+
+            while outputSize == 0 {
+                dstBuffer.deallocate()
+                dstSize *= 2
+                dstBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: dstSize)
+                outputSize = compression_encode_buffer(
+                    dstBuffer,
+                    dstSize,
+                    srcPtr,
+                    count,
+                    nil,
+                    algorithm
+                )
+            }
+
+            guard outputSize != 0 else {
+                dstBuffer.deallocate()
+                throw DataCompressionError.compressionFailed
+            }
+
+            let data = Data(bytes: dstBuffer, count: outputSize)
+            dstBuffer.deallocate()
+            return data
+        }
+    }
+
+    /// Decompresses the data using the supplied algorithm.
+    func decompressed(using algorithm: compression_algorithm) throws -> Data {
+        guard !isEmpty else { return self }
+
+        return try withUnsafeBytes { (srcBuffer: UnsafeRawBufferPointer) -> Data in
+            guard let srcPtr = srcBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                throw DataCompressionError.decompressionFailed
+            }
+
+            var dstSize = count * 4
+            var dstBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: dstSize)
+            var outputSize = compression_decode_buffer(
+                dstBuffer,
+                dstSize,
+                srcPtr,
+                count,
+                nil,
+                algorithm
+            )
+
+            while outputSize == 0 {
+                dstBuffer.deallocate()
+                dstSize *= 2
+                dstBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: dstSize)
+                outputSize = compression_decode_buffer(
+                    dstBuffer,
+                    dstSize,
+                    srcPtr,
+                    count,
+                    nil,
+                    algorithm
+                )
+            }
+
+            guard outputSize != 0 else {
+                dstBuffer.deallocate()
+                throw DataCompressionError.decompressionFailed
+            }
+
+            let data = Data(bytes: dstBuffer, count: outputSize)
+            dstBuffer.deallocate()
+            return data
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Switch countdown share encoding to binary property lists with LZFSE compression to shorten links
- Add data compression helpers built on `compression_encode_buffer`/`compression_decode_buffer` for reliable export and import
- Fix share service to use `COMPRESSION_LZFSE` constant so compression builds correctly

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a86e17a4a483338da88039755abc14