### PR TITLE
Refine Add/Edit countdown time options

### DIFF
--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -42,7 +42,6 @@ struct AddEditCountdownView: View {
 
     @State private var title: String = ""
     @State private var date: Date = Date().addingTimeInterval(86_400)
-    @State private var includeTime: Bool = false
     @State private var timeZoneID: String = TimeZone.current.identifier
 
     // Background selection
@@ -119,30 +118,26 @@ struct AddEditCountdownView: View {
 
                     // MARK: Details
                     SettingsCard {
-                        Text("Details")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.secondary)
-
                         TextField("Title (e.g., Anniversary)", text: $title)
                             .textInputAutocapitalization(.words)
                             .onSubmit { lightHaptic() }
 
-                        Toggle("Include time", isOn: $includeTime)
-
-                        DatePicker(
-                            "Date",
-                            selection: $date,
-                            displayedComponents: includeTime ? [.date, .hourAndMinute] : [.date]
-                        )
-
                         HStack {
-                            Text("Time Zone")
-                            Spacer()
-                            Text(TimeZone(identifier: timeZoneID)?.identifier ?? "System")
-                                .foregroundStyle(.secondary)
+                            DatePicker("Date", selection: $date, displayedComponents: .date)
+                            DatePicker("", selection: $date, displayedComponents: .hourAndMinute)
+                                .labelsHidden()
                         }
-                        .contentShape(Rectangle())
-                        .onTapGesture { timeZoneID = TimeZone.current.identifier }
+
+                        NavigationLink {
+                            TimeZonePickerView(selectedID: $timeZoneID)
+                        } label: {
+                            HStack {
+                                Text("Time Zone")
+                                Spacer()
+                                Text(TimeZone(identifier: timeZoneID)?.identifier ?? "System")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
                     }
 
                     // MARK: Background
@@ -330,7 +325,6 @@ struct AddEditCountdownView: View {
                     title = existing.title
                     date = existing.targetDate
                     timeZoneID = existing.timeZoneID
-                    includeTime = hasTime(existing.targetDate)
                     backgroundStyle = existing.backgroundStyle
                     colorHex = existing.backgroundColorHex ?? colorHex
                     imageData = existing.backgroundImageData
@@ -414,11 +408,6 @@ struct AddEditCountdownView: View {
         case 4320: return .d3
         default:  return .none
         }
-    }
-
-    private func hasTime(_ d: Date) -> Bool {
-        let c = Calendar.current.dateComponents([.hour,.minute,.second], from: d)
-        return (c.hour ?? 0) != 0 || (c.minute ?? 0) != 0 || (c.second ?? 0) != 0
     }
 
     @ViewBuilder

--- a/CouplesCount/Views/TimeZonePickerView.swift
+++ b/CouplesCount/Views/TimeZonePickerView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct TimeZonePickerView: View {
+    @Binding var selectedID: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List(TimeZone.knownTimeZoneIdentifiers, id: \.self) { id in
+            HStack {
+                Text(id)
+                Spacer()
+                if id == selectedID {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                selectedID = id
+                dismiss()
+            }
+        }
+        .navigationTitle("Time Zone")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}


### PR DESCRIPTION
## Summary
- remove "Details" header and include-time toggle from add/edit view
- show date and time pickers side by side
- allow selecting a different time zone via new picker view

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b152134483339a63cb8b7b3bf360