### PR TITLE
Add title font style picker to countdowns

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -88,17 +88,18 @@ struct CountdownListView: View {
                         }
                         Spacer()
                     } else {
-                          List {
-                              ForEach(items) { item in
-                                  // Compute per-item display values
-                                  let days = DateUtils.daysUntil(
-                                      target: item.targetDate,
-                                      in: item.timeZoneID
-                                  )
-                                  let dateText = DateUtils.readableDate.string(from: item.targetDate)
-                                  let exportURL = CountdownShareService.exportURL(for: item)
+                        List {
+                            ForEach(items) { item in
+                                // Compute per-item display values
+                                let days = DateUtils.daysUntil(
+                                    target: item.targetDate,
+                                    in: item.timeZoneID
+                                )
+                                let dateText = DateUtils.readableDate.string(from: item.targetDate)
+                                let exportURL = CountdownShareService.exportURL(for: item)
 
-                                CountdownCardView(
+                                // Build the countdown card separately to reduce type-checking complexity
+                                let card = CountdownCardView(
                                     title: item.title,
                                     daysLeft: days,
                                     dateText: dateText,
@@ -106,60 +107,62 @@ struct CountdownListView: View {
                                     backgroundStyle: item.backgroundStyle,
                                     colorHex: item.backgroundColorHex,
                                     imageData: item.backgroundImageData,
+                                    titleFontName: item.titleFontName,
                                     shared: item.isShared,
                                     shareAction: {
                                         shareURL = exportURL
                                         showShareSheet = shareURL != nil
                                     }
-
                                 )
-                                .environmentObject(theme)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    editing = item
-                                    showAddEdit = true
-                                }
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
-                                .listRowBackground(theme.theme.background)
-                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                    Button {
-                                        withAnimation(.easeInOut) {
-                                            modelContext.delete(item)
-                                            try? modelContext.save()
-                                          }
-                                      } label: {
-                                          Image(systemName: "trash")
-                                              .font(.system(size: 16, weight: .bold))
-                                              .padding(12)
-                                              .background(Circle().fill(Color.red))
-                                              .foregroundStyle(.white)
-                                      }
-                                      .tint(.clear)
-                                  }
-                                  .swipeActions(edge: .leading, allowsFullSwipe: false) {
-                                      Button {
-                                          withAnimation(.easeInOut) {
-                                              item.isArchived.toggle()
-                                              try? modelContext.save()
-                                          }
-                                      } label: {
-                                          Image(systemName: item.isArchived ? "arrow.uturn.backward" : "archivebox")
-                                              .font(.system(size: 16, weight: .bold))
-                                              .padding(12)
-                                              .background(Circle().fill(Color.blue))
-                                              .foregroundStyle(.white)
-                                      }
-                                      .tint(.clear)
-                                  }
+
+                                card
+                                    .environmentObject(theme)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        editing = item
+                                        showAddEdit = true
+                                    }
+                                    .listRowSeparator(.hidden)
+                                    .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
+                                    .listRowBackground(theme.theme.background)
+                                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                        Button {
+                                            withAnimation(.easeInOut) {
+                                                modelContext.delete(item)
+                                                try? modelContext.save()
+                                            }
+                                        } label: {
+                                            Image(systemName: "trash")
+                                                .font(.system(size: 16, weight: .bold))
+                                                .padding(12)
+                                                .background(Circle().fill(Color.red))
+                                                .foregroundStyle(.white)
+                                        }
+                                        .tint(.clear)
+                                    }
+                                    .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                        Button {
+                                            withAnimation(.easeInOut) {
+                                                item.isArchived.toggle()
+                                                try? modelContext.save()
+                                            }
+                                        } label: {
+                                            Image(systemName: item.isArchived ? "arrow.uturn.backward" : "archivebox")
+                                                .font(.system(size: 16, weight: .bold))
+                                                .padding(12)
+                                                .background(Circle().fill(Color.blue))
+                                                .foregroundStyle(.white)
+                                        }
+                                        .tint(.clear)
+                                    }
                             }
                         }
-                          .listStyle(.plain)
-                          .listRowSpacing(16)
-                          .padding(.top, 28)
-                          .scrollContentBackground(.hidden)
-                          .animation(.easeInOut, value: items)
-                      }
+                        .listStyle(.plain)
+                        .listRowSpacing(16)
+                        .padding(.top, 28)
+                        .scrollContentBackground(.hidden)
+                        .animation(.easeInOut, value: items)
+                    }
                 }
 
                 // Centered bottom +

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -43,6 +43,7 @@ struct AddEditCountdownView: View {
     @State private var title: String = ""
     @State private var date: Date = Date().addingTimeInterval(86_400)
     @State private var timeZoneID: String = TimeZone.current.identifier
+    @State private var titleFont: TitleFont = .default
 
     // Background selection
     @State private var backgroundStyle: String = "color" // "color" | "image"
@@ -85,6 +86,7 @@ struct AddEditCountdownView: View {
                             title: previewTitle,
                             targetDate: previewDate,
                             tzID: timeZoneID,
+                            titleFontName: titleFont.rawValue,
                             backgroundStyle: backgroundStyle,
                             bgColorHex: previewColorHex,
                             imageData: previewImageData
@@ -98,6 +100,7 @@ struct AddEditCountdownView: View {
                             title: previewTitle,
                             targetDate: previewDate,
                             tzID: timeZoneID,
+                            titleFontName: titleFont.rawValue,
                             backgroundStyle: backgroundStyle,
                             bgColorHex: previewColorHex,
                             imageData: previewImageData
@@ -121,6 +124,14 @@ struct AddEditCountdownView: View {
                         TextField("Title (e.g., Anniversary)", text: $title)
                             .textInputAutocapitalization(.words)
                             .onSubmit { lightHaptic() }
+
+                        Picker("Font", selection: $titleFont) {
+                            ForEach(TitleFont.allCases) { f in
+                                Text(f.displayName).tag(f)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .onChange(of: titleFont, initial: false) { _, _ in lightHaptic() }
 
                         HStack {
                             DatePicker("Date", selection: $date, displayedComponents: .date)
@@ -325,6 +336,7 @@ struct AddEditCountdownView: View {
                     title = existing.title
                     date = existing.targetDate
                     timeZoneID = existing.timeZoneID
+                    titleFont = TitleFont(rawValue: existing.titleFontName) ?? .default
                     backgroundStyle = existing.backgroundStyle
                     colorHex = existing.backgroundColorHex ?? colorHex
                     imageData = existing.backgroundImageData
@@ -365,6 +377,7 @@ struct AddEditCountdownView: View {
                 existing.title = trimmed
                 existing.targetDate = date
                 existing.timeZoneID = timeZoneID
+                existing.titleFontName = titleFont.rawValue
                 existing.backgroundStyle = backgroundStyle
                 existing.backgroundColorHex = colorHex
                 existing.backgroundImageData = imageData
@@ -378,6 +391,7 @@ struct AddEditCountdownView: View {
                     title: trimmed,
                     targetDate: date,
                     timeZoneID: timeZoneID,
+                    titleFontName: titleFont.rawValue,
                     backgroundStyle: backgroundStyle,
                     backgroundColorHex: colorHex,
                     backgroundImageData: imageData,

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -10,6 +10,7 @@ struct CountdownCardView: View {
     let backgroundStyle: String
     let colorHex: String?
     let imageData: Data?
+    let titleFontName: String = TitleFont.default.rawValue
     let shared: Bool
     let shareAction: (() -> Void)?
 
@@ -45,7 +46,7 @@ struct CountdownCardView: View {
             // Content
             VStack(alignment: .leading, spacing: 8) {
                 Text(title)
-                    .font(.headline)
+                    .font(.system(.headline, design: TitleFont(rawValue: titleFontName)?.design ?? .default))
                     .lineLimit(1)
 
                 Text("\(daysLeft) days")

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -107,7 +107,6 @@ struct ProfileView: View {
                             imageData: item.backgroundImageData,
                             shared: item.isShared,
                             shareAction: nil
-
                         )
                         .environmentObject(theme)
                         .contextMenu {

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -4,6 +4,7 @@ struct WidgetPreview: View {
     let title: String
     let targetDate: Date
     let tzID: String
+    let titleFontName: String
     let backgroundStyle: String
     let bgColorHex: String?
     let imageData: Data?
@@ -27,7 +28,7 @@ struct WidgetPreview: View {
 
             VStack(spacing: 6) {
                 Text(title)
-                    .font(.headline)
+                    .font(.system(.headline, design: TitleFont(rawValue: titleFontName)?.design ?? .default))
                     .foregroundStyle(.white)
                     .lineLimit(1)
 

--- a/CouplesCountWidget/CouplesCountWidget.swift
+++ b/CouplesCountWidget/CouplesCountWidget.swift
@@ -53,7 +53,7 @@ struct CouplesCountWidgetView: View {
     var body: some View {
         VStack(spacing: 6) {
             Text(entry.entity.title)
-                .font(.headline)
+                .font(.system(.headline, design: TitleFont(rawValue: entry.entity.titleFontName)?.design ?? .default))
                 .lineLimit(1)
 
             Text(daysText(to: entry.entity.targetDate, tzID: entry.entity.timeZoneID))

--- a/CouplesCountWidget/WidgetIntents/CountdownEntity.swift
+++ b/CouplesCountWidget/WidgetIntents/CountdownEntity.swift
@@ -1,6 +1,7 @@
 import AppIntents
 import Foundation
 import SwiftData
+import SwiftUI
 
 // MARK: - Storage bridge (works now without App Group; reads real data later)
 enum WidgetStoreBridge {
@@ -47,6 +48,7 @@ struct CountdownEntity: AppEntity, Identifiable, Hashable {
     var title: String
     var targetDate: Date
     var timeZoneID: String
+    var titleFontName: String
 
     // How each item shows up in the picker
     var displayRepresentation: DisplayRepresentation {
@@ -58,7 +60,8 @@ struct CountdownEntity: AppEntity, Identifiable, Hashable {
         id: UUID(),
         title: "Anniversary",
         targetDate: Calendar.current.date(byAdding: .day, value: 30, to: .now)!,
-        timeZoneID: TimeZone.current.identifier
+        timeZoneID: TimeZone.current.identifier,
+        titleFontName: TitleFont.default.rawValue
     )
 }
 
@@ -80,7 +83,8 @@ struct CountdownQuery: EntityQuery {
             CountdownEntity(id: $0.id,
                             title: $0.title,
                             targetDate: $0.targetDate,
-                            timeZoneID: $0.timeZoneID)
+                            timeZoneID: $0.timeZoneID,
+                            titleFontName: $0.titleFontName)
         }
     }
 }

--- a/Services/CountdownShareService.swift
+++ b/Services/CountdownShareService.swift
@@ -6,6 +6,7 @@ struct CountdownShareData: Codable {
     let title: String
     let targetDate: Date
     let timeZoneID: String
+    let titleFontName: String
     let backgroundStyle: String
     let backgroundColorHex: String?
     let backgroundImageData: Data?
@@ -33,6 +34,7 @@ enum CountdownShareService {
             title: countdown.title,
             targetDate: countdown.targetDate,
             timeZoneID: countdown.timeZoneID,
+            titleFontName: countdown.titleFontName,
             backgroundStyle: countdown.backgroundStyle,
             backgroundColorHex: countdown.backgroundColorHex,
             backgroundImageData: countdown.backgroundImageData
@@ -77,6 +79,7 @@ enum CountdownShareService {
             title: payload.title,
             targetDate: payload.targetDate,
             timeZoneID: payload.timeZoneID,
+            titleFontName: payload.titleFontName,
             backgroundStyle: payload.backgroundStyle,
             backgroundColorHex: payload.backgroundColorHex,
             backgroundImageData: payload.backgroundImageData

--- a/Shared/Models/Countdown.swift
+++ b/Shared/Models/Countdown.swift
@@ -9,6 +9,9 @@ final class Countdown {
     var timeZoneID: String
     var isArchived: Bool
 
+    // Title font style ("default", "rounded", etc.)
+    var titleFontName: String
+
     // Background
     // "color" or "image"
     var backgroundStyle: String
@@ -29,6 +32,7 @@ final class Countdown {
          targetDate: Date,
          timeZoneID: String,
          isArchived: Bool = false,
+         titleFontName: String = TitleFont.default.rawValue,
          backgroundStyle: String = "color",
          backgroundColorHex: String? = "#0A84FF",
          backgroundImageData: Data? = nil,
@@ -40,6 +44,7 @@ final class Countdown {
         self.targetDate = targetDate
         self.timeZoneID = timeZoneID
         self.isArchived = isArchived
+        self.titleFontName = titleFontName
         self.backgroundStyle = backgroundStyle
         self.backgroundColorHex = backgroundColorHex
         self.backgroundImageData = backgroundImageData

--- a/Shared/Models/TitleFont.swift
+++ b/Shared/Models/TitleFont.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+enum TitleFont: String, CaseIterable, Identifiable, Codable {
+    case `default`, rounded, serif, monospaced
+    var id: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .default: return "Default"
+        case .rounded: return "Rounded"
+        case .serif: return "Serif"
+        case .monospaced: return "Monospaced"
+        }
+    }
+    var design: Font.Design {
+        switch self {
+        case .default: return .default
+        case .rounded: return .rounded
+        case .serif: return .serif
+        case .monospaced: return .monospaced
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow choosing title font (default, rounded, serif, monospaced) for countdown cards and widgets
- persist selected font on Countdown model and share links
- render countdown cards and widgets with the chosen font without changing overall app typography
- break up complex list row in `ContentView` to resolve type-checker hang

## Testing
- ⚠️ `swift test` *(Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b31ea3008333805aa97a6966b30c