### PR TITLE
Handle SwiftData container load failures

### DIFF
--- a/Shared/Utilities/Persistence.swift
+++ b/Shared/Utilities/Persistence.swift
@@ -17,11 +17,19 @@ enum Persistence {
         }
 
         let config = ModelConfiguration(url: url)
+        let schema = Schema([Countdown.self, Friend.self])
         do {
-            let schema = Schema([Countdown.self, Friend.self])
             return try ModelContainer(for: schema, configurations: [config])
         } catch {
-            fatalError("ModelContainer error: \(error)")
+            // If the persistent store is incompatible or corrupt, remove it and retry
+            do {
+                if FileManager.default.fileExists(atPath: url.path) {
+                    try FileManager.default.removeItem(at: url)
+                }
+                return try ModelContainer(for: schema, configurations: [config])
+            } catch {
+                fatalError("ModelContainer error: \(error)")
+            }
         }
     }()
 }


### PR DESCRIPTION
## Summary
- reset SwiftData persistent store when the container fails to load so that a fresh container can be created

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c49b5bec8333b221bd8f5bb8916f