### PR TITLE
Add multiple reminders for countdowns

### DIFF
--- a/Services/NotificationManager.swift
+++ b/Services/NotificationManager.swift
@@ -9,21 +9,22 @@ enum NotificationManager {
         }
     }
 
-    static func scheduleReminder(for cd: Countdown) {
-        guard let minutes = cd.reminderOffsetMinutes else { return }
-        let content = UNMutableNotificationContent()
-        content.title = "Upcoming: \(cd.title)"
-        content.body = "Happening \(minutes >= 60 ? "soon" : "very soon")."
-        content.sound = .default
+    static func scheduleReminders(for cd: Countdown) {
+        for offset in cd.reminderOffsets {
+            let content = UNMutableNotificationContent()
+            content.title = "Upcoming: \(cd.title)"
+            content.body = "Happening soon."
+            content.sound = .default
 
-        // Fire at targetDate - minutes
-        let fire = cd.targetDate.addingTimeInterval(TimeInterval(-minutes * 60))
-        guard fire > Date() else { return }
+            // Fire at targetDate + offset (offset negative = before event)
+            let fire = cd.targetDate.addingTimeInterval(TimeInterval(offset * 60))
+            guard fire > Date() else { continue }
 
-        let comps = Calendar.current.dateComponents([.year,.month,.day,.hour,.minute], from: fire)
-        let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
-        let req = UNNotificationRequest(identifier: "cd-\(cd.id)-\(minutes)", content: content, trigger: trigger)
-        UNUserNotificationCenter.current().add(req)
+            let comps = Calendar.current.dateComponents([.year,.month,.day,.hour,.minute], from: fire)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
+            let req = UNNotificationRequest(identifier: "cd-\(cd.id)-\(offset)", content: content, trigger: trigger)
+            UNUserNotificationCenter.current().add(req)
+        }
     }
 
     static func cancelAll(for id: UUID) {

--- a/Shared/Models/Countdown.swift
+++ b/Shared/Models/Countdown.swift
@@ -20,8 +20,8 @@ final class Countdown {
     // Raw image data (jpeg) when style == "image"
     var backgroundImageData: Data?
 
-    // Reminder offset in minutes before target (nil = no reminder)
-    var reminderOffsetMinutes: Int?
+    // Reminder offsets in minutes relative to target (e.g. -60 = 1h before)
+    var reminderOffsets: [Int]
 
     // Sharing
     var isShared: Bool
@@ -36,7 +36,7 @@ final class Countdown {
          backgroundStyle: String = "color",
          backgroundColorHex: String? = "#0A84FF",
          backgroundImageData: Data? = nil,
-         reminderOffsetMinutes: Int? = nil,
+         reminderOffsets: [Int] = [],
          isShared: Bool = false,
          sharedWith: [Friend] = []) {
         self.id = id
@@ -48,7 +48,7 @@ final class Countdown {
         self.backgroundStyle = backgroundStyle
         self.backgroundColorHex = backgroundColorHex
         self.backgroundImageData = backgroundImageData
-        self.reminderOffsetMinutes = reminderOffsetMinutes
+        self.reminderOffsets = reminderOffsets
         self.isShared = isShared
         self.sharedWith = sharedWith
     }


### PR DESCRIPTION
## Summary
- Support multiple countdown reminders stored as minute offsets
- Add reminders section with chip display and sheet of preset options
- Schedule notifications for each selected reminder

## Testing
- ⚠️ `swift test` *(missing Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c81ae78c8333a659e0f9b9da033a