### PR TITLE
Expand Countdown model for CloudKit

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -39,7 +39,7 @@ struct CountdownListView: View {
     @Environment(\.modelContext) private var modelContext
 
     @Query(filter: #Predicate<Countdown> { !$0.isArchived },
-           sort: \.targetDate, order: .forward)
+           sort: \.targetUTC, order: .forward)
     private var items: [Countdown]
 
     @State private var showAddEdit = false

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -402,7 +402,9 @@ struct AddEditCountdownView: View {
                 existing.backgroundStyle = backgroundStyle
                 existing.backgroundColorHex = colorHex
                 existing.backgroundImageData = imageData
+                existing.hasImage = backgroundStyle == "image"
                 existing.reminderOffsets = selectedReminders.map { $0.rawValue }
+                existing.lastEdited = .now
                 existing.isShared = isShared
                 existing.sharedWith = friends.filter { selectedFriends.contains($0.id) }
                 NotificationManager.cancelAll(for: existing.id)

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -6,7 +6,7 @@ struct ProfileView: View {
     @EnvironmentObject private var theme: ThemeManager
     @Environment(\.modelContext) private var modelContext
     @Query(filter: #Predicate<Countdown> { $0.isShared && !$0.isArchived },
-           sort: \Countdown.targetDate, order: .forward)
+           sort: \Countdown.targetUTC, order: .forward)
     private var shared: [Countdown]
 
     @AppStorage("profileImageData") private var profileImageData: Data?

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -176,7 +176,7 @@ struct ArchiveView: View {
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject private var theme: ThemeManager
     @Query(filter: #Predicate<Countdown> { $0.isArchived },
-           sort: \Countdown.targetDate, order: .forward)
+           sort: \Countdown.targetUTC, order: .forward)
     private var items: [Countdown]
 
     var body: some View {

--- a/CouplesCountWidget/WidgetIntents/CountdownEntity.swift
+++ b/CouplesCountWidget/WidgetIntents/CountdownEntity.swift
@@ -31,7 +31,7 @@ enum WidgetStoreBridge {
         let context = ModelContext(container)
         let descriptor = FetchDescriptor<Countdown>(
             predicate: #Predicate { !$0.isArchived },
-            sortBy: [.init(\.targetDate, order: .forward)]
+            sortBy: [.init(\.targetUTC, order: .forward)]
         )
         return (try? context.fetch(descriptor)) ?? []
     }

--- a/Shared/Models/Countdown.swift
+++ b/Shared/Models/Countdown.swift
@@ -5,27 +5,49 @@ import SwiftData
 final class Countdown {
     var id: UUID
     var title: String
-    var targetDate: Date
+    @Attribute(originalName: "targetDate") var targetUTC: Date
     var timeZoneID: String
-    var isArchived: Bool
+    var includeTime: Bool
+    @Attribute(originalName: "backgroundColorHex") var colorTheme: String
+    var hasImage: Bool
+    @Attribute(originalName: "backgroundImageData") var imageData: Data?
+    @Attribute(originalName: "titleFontName") var fontStyle: String
+    @Attribute(originalName: "reminderOffsets") var reminderOffsetsMinutes: [Int]
+    var lastEdited: Date
+    var version: Int
+    var ownerUserID: String?
 
-    // Title font style ("default", "rounded", etc.)
-    var titleFontName: String
-
-    // Background
-    // "color" or "image"
+    // Legacy fields
     var backgroundStyle: String
-    // HEX like "#3871FF" when style == "color"
-    var backgroundColorHex: String?
-    // Raw image data (jpeg) when style == "image"
-    var backgroundImageData: Data?
-
-    // Reminder offsets in minutes relative to target (e.g. -60 = 1h before)
-    var reminderOffsets: [Int]
-
-    // Sharing
+    var isArchived: Bool
     var isShared: Bool
     @Relationship(deleteRule: .cascade) var sharedWith: [Friend]
+
+    // Backwards-compatible accessors
+    var targetDate: Date {
+        get { targetUTC }
+        set { targetUTC = newValue }
+    }
+
+    var titleFontName: String {
+        get { fontStyle }
+        set { fontStyle = newValue }
+    }
+
+    var backgroundColorHex: String? {
+        get { colorTheme }
+        set { colorTheme = newValue ?? colorTheme }
+    }
+
+    var backgroundImageData: Data? {
+        get { imageData }
+        set { imageData = newValue }
+    }
+
+    var reminderOffsets: [Int] {
+        get { reminderOffsetsMinutes }
+        set { reminderOffsetsMinutes = newValue }
+    }
 
     init(id: UUID = UUID(),
          title: String,
@@ -41,14 +63,19 @@ final class Countdown {
          sharedWith: [Friend] = []) {
         self.id = id
         self.title = title
-        self.targetDate = targetDate
+        self.targetUTC = targetDate
         self.timeZoneID = timeZoneID
-        self.isArchived = isArchived
-        self.titleFontName = titleFontName
+        self.includeTime = true
+        self.colorTheme = backgroundColorHex ?? "#0A84FF"
+        self.hasImage = backgroundStyle == "image"
+        self.imageData = backgroundImageData
+        self.fontStyle = titleFontName
+        self.reminderOffsetsMinutes = reminderOffsets
+        self.lastEdited = .now
+        self.version = 1
+        self.ownerUserID = nil
         self.backgroundStyle = backgroundStyle
-        self.backgroundColorHex = backgroundColorHex
-        self.backgroundImageData = backgroundImageData
-        self.reminderOffsets = reminderOffsets
+        self.isArchived = isArchived
         self.isShared = isShared
         self.sharedWith = sharedWith
     }


### PR DESCRIPTION
## Summary
- Extend `Countdown` model with CloudKit-ready fields like `targetUTC`, `includeTime`, `colorTheme`, `hasImage`, `lastEdited`, `version`, and `ownerUserID`
- Provide backward-compatible accessors for legacy properties while mapping queries to `targetUTC`
- Record image and edit metadata when updating existing countdowns

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c9dcf61c83338a529a109bbf0932