### PR TITLE
Use real App Group for shared persistence

### DIFF
--- a/Shared/Theme/ThemeManager.swift
+++ b/Shared/Theme/ThemeManager.swift
@@ -3,8 +3,8 @@ import WidgetKit
 
 @MainActor
 final class ThemeManager: ObservableObject {
-    // When you join the paid program, change nil -> "group.com.fireblazer.CouplesCount"
-    private let appGroupSuite: String? = nil
+    // App Group identifier used for shared user defaults
+    private let appGroupSuite: String? = "group.com.fireblazer.CouplesCount"
     private let key = "global_color_theme"
 
     // Stored defaults, initialized before anything else is used.

--- a/Shared/Utilities/Persistence.swift
+++ b/Shared/Utilities/Persistence.swift
@@ -2,8 +2,8 @@ import Foundation
 import SwiftData
 
 enum Persistence {
-    // When you join the paid program, set this to your App Group id and use groupURL() below
-    private static let appGroupID: String? = nil
+    // App Group identifier used for shared storage
+    private static let appGroupID: String? = "group.com.fireblazer.CouplesCount"
 
     static var container: ModelContainer = {
         let url: URL


### PR DESCRIPTION
## Summary
- Tie persistence and theme defaults to the real `group.com.fireblazer.CouplesCount` App Group
- Load widget countdowns from shared JSON in the App Group container instead of opening SwiftData directly

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2cbb2208333956153139eae4394