### PR TITLE
Use AppGroup defaults in ThemeManager

### DIFF
--- a/Shared/Theme/ThemeManager.swift
+++ b/Shared/Theme/ThemeManager.swift
@@ -3,24 +3,12 @@ import WidgetKit
 
 @MainActor
 final class ThemeManager: ObservableObject {
-    // App Group identifier used for shared user defaults
-    private let appGroupSuite: String? = "group.com.fireblazer.CouplesCount"
     private let key = "global_color_theme"
-
-    // Stored defaults, initialized before anything else is used.
-    private let defaults: UserDefaults
+    private let defaults = AppGroup.defaults
 
     @Published var theme: ColorTheme
 
     init() {
-        // 1) Initialize defaults without touching 'self' computed properties.
-        if let suite = appGroupSuite, let d = UserDefaults(suiteName: suite) {
-            self.defaults = d
-        } else {
-            self.defaults = .standard
-        }
-
-        // 2) Initialize theme from defaults (must set all stored properties before using 'self').
         let raw = defaults.string(forKey: key)
         self.theme = ColorTheme(rawOrDefault: raw)
     }


### PR DESCRIPTION
## Summary
- Replace manual UserDefaults suite setup with AppGroup.defaults
- Simplify theme initialization and updates

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swiftc -typecheck Shared/Theme/ThemeManager.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a90f38926083338a074c2d7ddfe9df