### PR TITLE
Use AppGroup container URL for persistence

### DIFF
--- a/Shared/Utilities/Persistence.swift
+++ b/Shared/Utilities/Persistence.swift
@@ -2,19 +2,8 @@ import Foundation
 import SwiftData
 
 enum Persistence {
-    // App Group identifier used for shared storage
-    private static let appGroupID: String? = "group.com.fireblazer.CouplesCount"
-
     static var container: ModelContainer = {
-        let url: URL
-        if let group = appGroupID,
-           let base = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: group) {
-            url = base.appendingPathComponent("CouplesCount.store")
-        } else {
-            // Local documents directory (works on free provisioning)
-            let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            url = docs.appendingPathComponent("CouplesCount.store")
-        }
+        let url = AppGroup.containerURL.appendingPathComponent("CouplesCount.store")
 
         let config = ModelConfiguration(url: url)
         let schema = Schema([Countdown.self, Friend.self])


### PR DESCRIPTION
## Summary
- simplify persistence layer by using centralized AppGroup.containerURL

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a90f42e5b483339c155e28b5a86309