### PR TITLE
Include shared sources in widget extension

### DIFF
--- a/CouplesCount.xcodeproj/project.pbxproj
+++ b/CouplesCount.xcodeproj/project.pbxproj
@@ -78,16 +78,13 @@
 		83E9E7D82E53B34900B99B1D /* Exceptions for "Shared" folder in "CouplesCountWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Models/Countdown.swift,
-				Models/Friend.swift,
-				Models/TitleFont.swift,
-				Theme/ColorTheme.swift,
-				Theme/ThemeManager.swift,
-				Utilities/AppGroup.swift,
-				Utilities/DateUtils.swift,
-				Utilities/Persistence.swift,
-				Utilities/WidgetSnapshotStore.swift,
-			);
+                               Models/Countdown.swift,
+                               Models/Friend.swift,
+                               Theme/ColorTheme.swift,
+                               Theme/ThemeManager.swift,
+                               Utilities/DateUtils.swift,
+                               Utilities/Persistence.swift,
+                       );
 			target = 83E9E79A2E53AE3400B99B1D /* CouplesCountWidgetExtension */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */


### PR DESCRIPTION
## Summary
- Remove shared files from widget's membership exceptions so they build with CouplesCountWidgetExtension

## Testing
- `xcodebuild -list -project CouplesCount.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a90f451fcc83339f805710c6f57413