### PR TITLE
Schedule reminders for imported countdowns

### DIFF
--- a/Services/CountdownShareService.swift
+++ b/Services/CountdownShareService.swift
@@ -86,6 +86,7 @@ enum CountdownShareService {
         )
         context.insert(cd)
         try context.save()
+        NotificationManager.scheduleReminders(for: cd)
         let all = try context.fetch(FetchDescriptor<Countdown>())
         updateWidgetSnapshot(afterSaving: all)
     }


### PR DESCRIPTION
## Summary
- ensure imported countdowns schedule notifications by invoking `NotificationManager.scheduleReminders`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e32469208333bd4e2b20b798d15d