### PR TITLE
Stop notifications for archived countdowns

### DIFF
--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -274,6 +274,9 @@ struct AddEditCountdownView: View {
                         SettingsCard {
                             Button {
                                 existing.isArchived.toggle()
+                                if existing.isArchived {
+                                    NotificationManager.cancelReminders(for: existing.id)
+                                }
                                 try? modelContext.save()
                                 let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
                                 updateWidgetSnapshot(afterSaving: all)

--- a/Services/NotificationManager.swift
+++ b/Services/NotificationManager.swift
@@ -66,4 +66,13 @@ enum NotificationManager {
             center.removePendingNotificationRequests(withIdentifiers: toRemove)
         }
     }
+
+    static func cancelReminders(for id: UUID) {
+        let center = UNUserNotificationCenter.current()
+        center.getPendingNotificationRequests { reqs in
+            let prefix = "cd-\(id.uuidString)-"
+            let toRemove = reqs.filter { $0.identifier.hasPrefix(prefix) }.map { $0.identifier }
+            center.removePendingNotificationRequests(withIdentifiers: toRemove)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- cancel reminders when archiving a countdown
- add helper to cancel reminders by countdown id

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3f046e48333971e77612a12b1fa