### PR TITLE
feat: show relative time with hours and minutes

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -91,17 +91,14 @@ struct CountdownListView: View {
                         List {
                             ForEach(items) { item in
                                 // Compute per-item display values
-                                let days = DateUtils.daysUntil(
-                                    target: item.targetDate,
-                                    in: item.timeZoneID
-                                )
                                 let dateText = DateUtils.readableDate.string(from: item.targetDate)
                                 let exportURL = CountdownShareService.exportURL(for: item)
 
                                 // Build the countdown card separately to reduce type-checking complexity
                                 let card = CountdownCardView(
                                     title: item.title,
-                                    daysLeft: days,
+                                    targetDate: item.targetDate,
+                                    timeZoneID: item.timeZoneID,
                                     dateText: dateText,
                                     archived: item.isArchived,
                                     backgroundStyle: item.backgroundStyle,

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -4,7 +4,8 @@ struct CountdownCardView: View {
     @EnvironmentObject private var theme: ThemeManager
 
     let title: String
-    let daysLeft: Int
+    let targetDate: Date
+    let timeZoneID: String
     let dateText: String
     let archived: Bool
     let backgroundStyle: String
@@ -17,7 +18,8 @@ struct CountdownCardView: View {
 
     init(
         title: String,
-        daysLeft: Int,
+        targetDate: Date,
+        timeZoneID: String,
         dateText: String,
         archived: Bool,
         backgroundStyle: String,
@@ -28,7 +30,8 @@ struct CountdownCardView: View {
         shareAction: (() -> Void)? = nil
     ) {
         self.title = title
-        self.daysLeft = daysLeft
+        self.targetDate = targetDate
+        self.timeZoneID = timeZoneID
         self.dateText = dateText
         self.archived = archived
         self.backgroundStyle = backgroundStyle
@@ -42,6 +45,7 @@ struct CountdownCardView: View {
 
     private let corner: CGFloat = 22
     private let height: CGFloat = 120
+    @State private var now = Date()
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -74,7 +78,7 @@ struct CountdownCardView: View {
                     .font(.system(.headline, design: TitleFont(rawValue: titleFontName)?.design ?? .default))
                     .lineLimit(1)
 
-                Text("\(daysLeft) days")
+                Text(DateUtils.remainingText(to: targetDate, from: now, in: timeZoneID))
                     .font(.system(size: 34, weight: .bold, design: .rounded))
 
                 Text(dateText)
@@ -109,7 +113,8 @@ struct CountdownCardView: View {
         .opacity(archived ? 0.55 : 1)
         .animation(.easeInOut(duration: 0.2), value: archived)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title), \(daysLeft) days, \(dateText)")
+        .accessibilityLabel("\(title), \(DateUtils.remainingText(to: targetDate, from: now, in: timeZoneID)), \(dateText)")
+        .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }
     }
 
     private var accent: Color { theme.theme.accent }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -95,11 +95,11 @@ struct ProfileView: View {
                 // Grid of shared countdowns
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 2), spacing: 8) {
                     ForEach(shared) { item in
-                        let days = DateUtils.daysUntil(target: item.targetDate, in: item.timeZoneID)
                         let dateText = DateUtils.readableDate.string(from: item.targetDate)
                         CountdownCardView(
                             title: item.title,
-                            daysLeft: days,
+                            targetDate: item.targetDate,
+                            timeZoneID: item.timeZoneID,
                             dateText: dateText,
                             archived: item.isArchived,
                             backgroundStyle: item.backgroundStyle,

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -193,12 +193,12 @@ struct ArchiveView: View {
                 } else {
                     List {
                         ForEach(items) { item in
-                            let days = DateUtils.daysUntil(target: item.targetDate, in: item.timeZoneID)
                             let dateText = DateUtils.readableDate.string(from: item.targetDate)
 
                                 CountdownCardView(
                                     title: item.title,
-                                    daysLeft: days,
+                                    targetDate: item.targetDate,
+                                    timeZoneID: item.timeZoneID,
                                     dateText: dateText,
                                     archived: item.isArchived,
                                     backgroundStyle: item.backgroundStyle,

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -9,6 +9,8 @@ struct WidgetPreview: View {
     let bgColorHex: String?
     let imageData: Data?
 
+    @State private var now = Date()
+
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 22, style: .continuous)
@@ -32,7 +34,7 @@ struct WidgetPreview: View {
                     .foregroundStyle(.white)
                     .lineLimit(1)
 
-                Text("\(DateUtils.daysUntil(target: targetDate, in: tzID)) days")
+                Text(DateUtils.remainingText(to: targetDate, from: now, in: tzID))
                     .font(.system(size: 32, weight: .bold, design: .rounded))
                     .foregroundStyle(.white)
 
@@ -43,6 +45,7 @@ struct WidgetPreview: View {
             .shadow(color: .black.opacity(0.3), radius: 6, y: 3)
             .padding()
         }
+        .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }
     }
 
     private var backgroundFill: some ShapeStyle {

--- a/CouplesCountWidget/CouplesCountWidget.swift
+++ b/CouplesCountWidget/CouplesCountWidget.swift
@@ -56,7 +56,7 @@ struct CouplesCountWidgetView: View {
                 .font(.system(.headline, design: TitleFont(rawValue: entry.entity.titleFontName)?.design ?? .default))
                 .lineLimit(1)
 
-            Text(daysText(to: entry.entity.targetDate, tzID: entry.entity.timeZoneID))
+            Text(DateUtils.remainingText(to: entry.entity.targetDate, from: entry.date, in: entry.entity.timeZoneID))
                 .font(.system(size: 28, weight: .bold, design: .rounded))
 
             Text(entry.entity.targetDate, style: .date)
@@ -65,15 +65,6 @@ struct CouplesCountWidgetView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .containerBackground(.fill.tertiary, for: .widget)
-    }
-
-    private func daysText(to date: Date, tzID: String) -> String {
-        let tz = TimeZone(identifier: tzID) ?? .current
-        var cal = Calendar.current; cal.timeZone = tz
-        let start = cal.startOfDay(for: .now)
-        let end = cal.startOfDay(for: date)
-        let d = cal.dateComponents([.day], from: start, to: end).day ?? 0
-        return "\(d) days"
     }
 }
 

--- a/Shared/Utilities/DateUtils.swift
+++ b/Shared/Utilities/DateUtils.swift
@@ -9,6 +9,31 @@ enum DateUtils {
         return cal.dateComponents([.day], from: s, to: e).day ?? 0
     }
 
+    static func remainingText(to target: Date, from now: Date = .now, in tzID: String) -> String {
+        let tz = TimeZone(identifier: tzID) ?? .current
+        var cal = Calendar.current; cal.timeZone = tz
+
+        if now >= target { return "Today" }
+
+        let comps = cal.dateComponents([.day, .hour, .minute], from: now, to: target)
+        let d = comps.day ?? 0
+        if d >= 1 {
+            return "\(d) day" + (d == 1 ? "" : "s")
+        }
+
+        let h = comps.hour ?? 0
+        if h >= 1 {
+            return "\(h) hour" + (h == 1 ? "" : "s")
+        }
+
+        let m = comps.minute ?? 0
+        if m >= 1 {
+            return "\(m) minute" + (m == 1 ? "" : "s")
+        }
+
+        return "Today"
+    }
+
     static let readableDate: DateFormatter = {
         let df = DateFormatter()
         df.dateStyle = .medium


### PR DESCRIPTION
## Summary
- add DateUtils.remainingText for timezone-aware days/hours/minutes formatting with pluralization
- update countdown card, lists, previews, and widget to use remainingText and refresh every minute

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f4b5a03883338246d42edb4daa8e