### PR TITLE
Polish card interactions with spring animation and haptics

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -124,12 +124,13 @@ struct CountdownListView: View {
                                     .listRowBackground(theme.theme.background)
                                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                         Button {
-                                            withAnimation(.easeInOut) {
+                                            withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                                                 modelContext.delete(item)
                                                 try? modelContext.save()
                                                 let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
                                                 updateWidgetSnapshot(afterSaving: all)
                                             }
+                                            Haptics.warning()
                                         } label: {
                                             Image(systemName: "trash")
                                                 .font(.system(size: 16, weight: .bold))
@@ -141,12 +142,13 @@ struct CountdownListView: View {
                                     }
                                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                         Button {
-                                            withAnimation(.easeInOut) {
+                                            withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                                                 item.isArchived.toggle()
                                                 try? modelContext.save()
                                                 let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
                                                 updateWidgetSnapshot(afterSaving: all)
                                             }
+                                            if item.isArchived { Haptics.light() }
                                         } label: {
                                             Image(systemName: item.isArchived ? "arrow.uturn.backward" : "archivebox")
                                                 .font(.system(size: 16, weight: .bold))
@@ -162,7 +164,7 @@ struct CountdownListView: View {
                         .listRowSpacing(16)
                         .padding(.top, 28)
                         .scrollContentBackground(.hidden)
-                        .animation(.easeInOut, value: items)
+                        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: items)
                     }
                 }
 

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -273,13 +273,16 @@ struct AddEditCountdownView: View {
                     if let existing {
                         SettingsCard {
                             Button {
-                                existing.isArchived.toggle()
-                                if existing.isArchived {
-                                    NotificationManager.cancelReminders(for: existing.id)
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    existing.isArchived.toggle()
+                                    if existing.isArchived {
+                                        NotificationManager.cancelReminders(for: existing.id)
+                                    }
+                                    try? modelContext.save()
+                                    let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                    updateWidgetSnapshot(afterSaving: all)
                                 }
-                                try? modelContext.save()
-                                let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                updateWidgetSnapshot(afterSaving: all)
+                                if existing.isArchived { Haptics.light() }
                                 dismiss()
                             } label: {
                                 Label(existing.isArchived ? "Unarchive Countdown" : "Archive Countdown",
@@ -289,11 +292,14 @@ struct AddEditCountdownView: View {
 
                         SettingsCard {
                             Button(role: .destructive) {
-                                NotificationManager.cancelAll(for: existing.id)
-                                modelContext.delete(existing)
-                                try? modelContext.save()
-                                let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                updateWidgetSnapshot(afterSaving: all)
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    NotificationManager.cancelAll(for: existing.id)
+                                    modelContext.delete(existing)
+                                    try? modelContext.save()
+                                    let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                    updateWidgetSnapshot(afterSaving: all)
+                                }
+                                Haptics.warning()
                                 dismiss()
                             } label: {
                                 Label("Delete Countdown", systemImage: "trash")
@@ -429,7 +435,9 @@ struct AddEditCountdownView: View {
                     isShared: isShared,
                     sharedWith: friends.filter { selectedFriends.contains($0.id) }
                 )
-                modelContext.insert(cd)
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                    modelContext.insert(cd)
+                }
                 if !selectedReminders.isEmpty { NotificationManager.scheduleReminders(for: cd) }
             }
 

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -111,7 +111,7 @@ struct CountdownCardView: View {
         .frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
         .saturation(archived ? 0 : 1)
         .opacity(archived ? 0.55 : 1)
-        .animation(.easeInOut(duration: 0.2), value: archived)
+        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: archived)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(title), \(DateUtils.remainingText(to: targetDate, from: now, in: timeZoneID)), \(dateText)")
         .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -112,20 +112,26 @@ struct ProfileView: View {
                         .environmentObject(theme)
                         .contextMenu {
                             Button(role: .destructive) {
-                                modelContext.delete(item)
-                                try? modelContext.save()
-                                let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                updateWidgetSnapshot(afterSaving: all)
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    modelContext.delete(item)
+                                    try? modelContext.save()
+                                    let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                    updateWidgetSnapshot(afterSaving: all)
+                                }
+                                Haptics.warning()
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
                             .tint(.red)
 
                             Button {
-                                item.isArchived = true
-                                try? modelContext.save()
-                                let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                updateWidgetSnapshot(afterSaving: all)
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    item.isArchived = true
+                                    try? modelContext.save()
+                                    let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                    updateWidgetSnapshot(afterSaving: all)
+                                }
+                                Haptics.light()
                             } label: {
                                 Label("Archive", systemImage: "archivebox")
                             }
@@ -134,6 +140,7 @@ struct ProfileView: View {
                 }
                 .padding(.horizontal)
                 .padding(.top, 8)
+                .animation(.spring(response: 0.4, dampingFraction: 0.85), value: shared)
             }
         }
         .background(theme.theme.background.ignoresSafeArea())

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -213,10 +213,13 @@ struct ArchiveView: View {
                             .listRowInsets(.init(top: 0, leading: 16, bottom: 0, trailing: 16))
                             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                 Button {
-                                    modelContext.delete(item)
-                                    try? modelContext.save()
-                                    let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                    updateWidgetSnapshot(afterSaving: all)
+                                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                        modelContext.delete(item)
+                                        try? modelContext.save()
+                                        let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                        updateWidgetSnapshot(afterSaving: all)
+                                    }
+                                    Haptics.warning()
                                 } label: {
                                     Image(systemName: "trash")
                                         .font(.system(size: 16, weight: .bold))
@@ -228,10 +231,12 @@ struct ArchiveView: View {
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                 Button {
-                                    item.isArchived = false
-                                    try? modelContext.save()
-                                    let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                    updateWidgetSnapshot(afterSaving: all)
+                                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                        item.isArchived = false
+                                        try? modelContext.save()
+                                        let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                        updateWidgetSnapshot(afterSaving: all)
+                                    }
                                 } label: {
                                     Image(systemName: "arrow.uturn.backward")
                                         .font(.system(size: 16, weight: .bold))
@@ -245,6 +250,7 @@ struct ArchiveView: View {
                     }
                     .listStyle(.plain)
                     .padding(.top, 12)
+                    .animation(.spring(response: 0.4, dampingFraction: 0.85), value: items)
                 }
             }
             .navigationTitle("Archive")

--- a/Services/Haptics.swift
+++ b/Services/Haptics.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+enum Haptics {
+    static func light() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+    static func warning() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    }
+}


### PR DESCRIPTION
## Summary
- Add reusable `Haptics` helper for light and warning feedback
- Apply spring-based animations and haptic feedback to card add, archive, and delete actions
- Refine archived card animation with a spring effect

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f9b8bfb883338c10c132556cf377