### PR TITLE
Add detail screen and refine countdown card gestures

### DIFF
--- a/CouplesCount/Views/CountdownDetailView.swift
+++ b/CouplesCount/Views/CountdownDetailView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct CountdownDetailView: View {
+    @EnvironmentObject private var theme: ThemeManager
+    let countdown: Countdown
+
+    var body: some View {
+        ScrollView {
+            CountdownCardView(
+                title: countdown.title,
+                targetDate: countdown.targetDate,
+                timeZoneID: countdown.timeZoneID,
+                dateText: DateUtils.readableDate.string(from: countdown.targetDate),
+                archived: countdown.isArchived,
+                backgroundStyle: countdown.backgroundStyle,
+                colorHex: countdown.backgroundColorHex,
+                imageData: countdown.backgroundImageData,
+                titleFontName: countdown.titleFontName,
+                shared: countdown.isShared,
+                shareAction: nil
+            )
+            .environmentObject(theme)
+            .padding()
+        }
+        .background(theme.theme.background.ignoresSafeArea())
+        .navigationTitle(countdown.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    let countdown = Countdown(title: "Preview", targetDate: .now.addingTimeInterval(3600), timeZoneID: TimeZone.current.identifier)
+    return NavigationStack {
+        CountdownDetailView(countdown: countdown)
+            .environmentObject(ThemeManager())
+    }
+}


### PR DESCRIPTION
## Summary
- Show a new countdown detail screen when tapping a card
- Long-pressing a card pops with haptics, opens edit sheet, and scales the card
- Wire up navigation destination for detail view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fb073bc48333ab087a63b82f5a2b