### PR TITLE
Add countdown detail sheet with hero card and engagement stubs

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -225,9 +225,11 @@ struct CountdownListView: View {
                     ShareSheet(activityItems: [shareURL])
                 }
             }
-            .navigationDestination(item: $selected) { countdown in
+            .sheet(item: $selected) { countdown in
                 CountdownDetailView(countdown: countdown)
                     .environmentObject(theme)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
             }
         }
         .tint(theme.theme.accent)

--- a/CouplesCount/Views/Components/TreeGrowthView.swift
+++ b/CouplesCount/Views/Components/TreeGrowthView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct TreeGrowthView: View {
+    var progress: Double
+    @State private var animated: Double = 0
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .bottom) {
+                Rectangle()
+                    .fill(Color.brown)
+                    .frame(width: geo.size.width * 0.1,
+                           height: geo.size.height * CGFloat(animated))
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: geo.size.width * 0.6,
+                           height: geo.size.width * 0.6)
+                    .scaleEffect(animated)
+                    .offset(y: -geo.size.height * CGFloat(animated))
+                if animated >= 1 {
+                    Text("🎉")
+                        .font(.largeTitle)
+                        .offset(y: -geo.size.height * 0.8)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(.easeInOut(duration: 1.0), value: animated)
+        }
+        .onAppear { animated = progress }
+        .onChange(of: progress) { animated = $0 }
+    }
+}
+
+#Preview {
+    TreeGrowthView(progress: 0.5)
+        .frame(width: 100, height: 100)
+}

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -15,6 +15,7 @@ struct CountdownCardView: View {
 
     let shared: Bool
     let shareAction: (() -> Void)?
+    let height: CGFloat
 
     init(
         title: String,
@@ -27,7 +28,8 @@ struct CountdownCardView: View {
         imageData: Data?,
         titleFontName: String = TitleFont.default.rawValue,
         shared: Bool,
-        shareAction: (() -> Void)? = nil
+        shareAction: (() -> Void)? = nil,
+        height: CGFloat = 120
     ) {
         self.title = title
         self.targetDate = targetDate
@@ -40,11 +42,11 @@ struct CountdownCardView: View {
         self.titleFontName = titleFontName
         self.shared = shared
         self.shareAction = shareAction
+        self.height = height
     }
 
 
     private let corner: CGFloat = 22
-    private let height: CGFloat = 120
     @State private var now = Date()
 
     var body: some View {

--- a/CouplesCount/Views/CountdownDetailView.swift
+++ b/CouplesCount/Views/CountdownDetailView.swift
@@ -1,37 +1,199 @@
 import SwiftUI
+import SwiftData
 
 struct CountdownDetailView: View {
     @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
     let countdown: Countdown
+
+    @State private var showShareSheet = false
+    @State private var shareURL: URL? = nil
+    @State private var showEdit = false
+    @State private var showDeleteAlert = false
+    @State private var now = Date()
+    @State private var progress: Double = 0
+    @State private var showPokeToast = false
+    @State private var toastMessage = ""
+    @State private var streak: Int = 0
+
+    private let participantsStore = ParticipantsStore()
 
     var body: some View {
         ScrollView {
-            CountdownCardView(
-                title: countdown.title,
-                targetDate: countdown.targetDate,
-                timeZoneID: countdown.timeZoneID,
-                dateText: DateUtils.readableDate.string(from: countdown.targetDate),
-                archived: countdown.isArchived,
-                backgroundStyle: countdown.backgroundStyle,
-                colorHex: countdown.backgroundColorHex,
-                imageData: countdown.backgroundImageData,
-                titleFontName: countdown.titleFontName,
-                shared: countdown.isShared,
-                shareAction: nil
-            )
-            .environmentObject(theme)
-            .padding()
+            VStack(spacing: 24) {
+                hero
+                info
+                sharedSection
+                TreeGrowthView(progress: progress)
+                    .frame(height: 180)
+                Button("Remind me to check in") {
+                    NotificationManager.scheduleCheckInReminder()
+                    Analytics.log("reminder_stub_tapped")
+                }
+                .buttonStyle(.borderedProminent)
+                Text("You checked this \(streak) days in a row")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 40)
         }
         .background(theme.theme.background.ignoresSafeArea())
-        .navigationTitle(countdown.title)
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Close") { dismiss() }
+            }
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button(action: share) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                Button(action: { showEdit = true }) {
+                    Image(systemName: "pencil")
+                }
+                Menu {
+                    Button(countdown.isArchived ? "Unarchive" : "Archive") {
+                        toggleArchive()
+                    }
+                    Button("Delete", role: .destructive) { showDeleteAlert = true }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+        .sheet(isPresented: $showShareSheet, onDismiss: { Haptics.success() }) {
+            if let shareURL { ShareSheet(activityItems: [shareURL]) }
+        }
+        .sheet(isPresented: $showEdit) {
+            AddEditCountdownView(existing: countdown)
+                .environmentObject(theme)
+        }
+        .alert("Delete Countdown?", isPresented: $showDeleteAlert) {
+            Button("Delete", role: .destructive) {
+                modelContext.delete(countdown)
+                try? modelContext.save()
+                Haptics.warning()
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .overlay(alignment: .bottom) {
+            if showPokeToast {
+                Text(toastMessage)
+                    .padding()
+                    .background(.black.opacity(0.7))
+                    .foregroundStyle(.white)
+                    .cornerRadius(8)
+                    .padding(.bottom, 40)
+                    .transition(.opacity)
+            }
+        }
+        .onAppear {
+            Analytics.log("detail_view_opened")
+            updateProgress()
+            incrementStreak()
+        }
+        .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { t in
+            now = t
+            updateProgress()
+        }
+        .accessibilityLabel("Countdown \(countdown.title), \(DateUtils.remainingText(to: countdown.targetDate, from: now, in: countdown.timeZoneID))")
+    }
+
+    private var hero: some View {
+        let width = UIScreen.main.bounds.width - 32
+        return CountdownCardView(
+            title: countdown.title,
+            targetDate: countdown.targetDate,
+            timeZoneID: countdown.timeZoneID,
+            dateText: DateUtils.readableDate.string(from: countdown.targetDate),
+            archived: countdown.isArchived,
+            backgroundStyle: countdown.backgroundStyle,
+            colorHex: countdown.backgroundColorHex,
+            imageData: countdown.backgroundImageData,
+            titleFontName: countdown.titleFontName,
+            shared: countdown.isShared,
+            shareAction: nil,
+            height: width
+        )
+        .environmentObject(theme)
+        .frame(width: width, height: width)
+    }
+
+    private var info: some View {
+        VStack(spacing: 8) {
+            Text(countdown.title)
+                .font(.title.bold())
+            Text(DateUtils.readableDate.string(from: countdown.targetDate))
+            Text(DateUtils.remainingText(to: countdown.targetDate, from: now, in: countdown.timeZoneID))
+                .font(.title2.weight(.semibold))
+        }
+        .multilineTextAlignment(.center)
+    }
+
+    private var sharedSection: some View {
+        let participants = participantsStore.participants(for: countdown)
+        return VStack(alignment: .leading, spacing: 8) {
+            if participants.isEmpty {
+                Button("Share with partner") { share() }
+                    .font(.subheadline)
+            } else {
+                DisclosureGroup("Shared With") {
+                    ForEach(participants) { p in
+                        HStack {
+                            p.image
+                            Text(p.name)
+                            Spacer()
+                            Button("Poke") { poke(p) }
+                                .buttonStyle(.bordered)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+    }
+
+    private func poke(_ p: Participant) {
+        PokeService.sendPoke(countdownID: countdown.id, userID: p.id)
+        toastMessage = "Poked \(p.name)"
+        withAnimation { showPokeToast = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation { showPokeToast = false }
+        }
+        Haptics.light()
+        Analytics.log("poke_tapped")
+    }
+
+    private func share() {
+        shareURL = CountdownShareService.exportURL(for: countdown)
+        showShareSheet = shareURL != nil
+        Analytics.log("share_tapped")
+    }
+
+    private func toggleArchive() {
+        countdown.isArchived.toggle()
+        try? modelContext.save()
+    }
+
+    private func updateProgress() {
+        let start = countdown.lastEdited
+        let total = countdown.targetDate.timeIntervalSince(start)
+        guard total > 0 else { progress = 1; return }
+        progress = max(0, min(1, now.timeIntervalSince(start) / total))
+    }
+
+    private func incrementStreak() {
+        let key = "streak-\(countdown.id.uuidString)"
+        let current = UserDefaults.standard.integer(forKey: key)
+        streak = current + 1
+        UserDefaults.standard.set(streak, forKey: key)
     }
 }
 
 #Preview {
     let countdown = Countdown(title: "Preview", targetDate: .now.addingTimeInterval(3600), timeZoneID: TimeZone.current.identifier)
-    return NavigationStack {
-        CountdownDetailView(countdown: countdown)
-            .environmentObject(ThemeManager())
-    }
+    return CountdownDetailView(countdown: countdown)
+        .environmentObject(ThemeManager())
 }

--- a/Services/Analytics.swift
+++ b/Services/Analytics.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum Analytics {
+    static func log(_ event: String) {
+        #if DEBUG
+        print("Analytics event: \(event)")
+        #endif
+    }
+}

--- a/Services/NotificationManager.swift
+++ b/Services/NotificationManager.swift
@@ -75,4 +75,20 @@ enum NotificationManager {
             center.removePendingNotificationRequests(withIdentifiers: toRemove)
         }
     }
+
+    static func scheduleCheckInReminder() {
+        let content = UNMutableNotificationContent()
+        content.title = "Check in"
+        content.body = "See how your countdowns are doing."
+        content.sound = .default
+
+        var cal = Calendar.current
+        cal.timeZone = .current
+        let tomorrow = cal.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        var comps = cal.dateComponents([.year, .month, .day], from: tomorrow)
+        comps.hour = 9
+        let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
+        let req = UNNotificationRequest(identifier: "checkin-\(UUID().uuidString)", content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(req)
+    }
 }

--- a/Services/ParticipantsStore.swift
+++ b/Services/ParticipantsStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftUI
+
+struct Participant: Identifiable {
+    let id: UUID
+    let name: String
+    let image: Image
+}
+
+protocol ParticipantsStoreProtocol {
+    func participants(for countdown: Countdown) -> [Participant]
+}
+
+struct ParticipantsStore: ParticipantsStoreProtocol {
+    func participants(for countdown: Countdown) -> [Participant] {
+        // Placeholder participants
+        return [
+            Participant(id: UUID(), name: "Alex", image: Image(systemName: "person.circle")),
+            Participant(id: UUID(), name: "Sam", image: Image(systemName: "person.circle"))
+        ]
+    }
+}

--- a/Services/PokeService.swift
+++ b/Services/PokeService.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+protocol PokeServiceProtocol {
+    static func sendPoke(countdownID: UUID, userID: UUID)
+}
+
+enum PokeService: PokeServiceProtocol {
+    static func sendPoke(countdownID: UUID, userID: UUID) {
+        // Stub implementation
+        #if DEBUG
+        print("Poke to \(userID) for countdown \(countdownID)")
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- Present countdown detail as a sheet with hero card, toolbar actions, shared-participants section, tree growth animation, and reminder/streak stubs
- Allow card view to render at custom heights for a large hero layout
- Stub out poke, analytics, and participant services with a new check-in reminder scheduler

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a9fd5088548333a2ee0d9c857d6054