### PR TITLE
Add onboarding flow with notification permission

### DIFF
--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -4,16 +4,37 @@ import SwiftData
 @main
 struct CouplesCountApp: App {
     @StateObject private var theme = ThemeManager()
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
+    @State private var showDeniedInfo = false
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(theme)
-                // Use a custom container so the widget and app share data
-                .modelContainer(Persistence.container)
-                .onAppear {
-                    NotificationManager.requestAuthorizationIfNeeded()
+            Group {
+                if hasSeenOnboarding {
+                    ContentView()
+                        .environmentObject(theme)
+                        // Use a custom container so the widget and app share data
+                        .modelContainer(Persistence.container)
+                } else {
+                    OnboardingView {
+                        showDeniedInfo = true
+                    }
+                    .environmentObject(theme)
                 }
+            }
+            .sheet(isPresented: $showDeniedInfo) {
+                VStack(spacing: 16) {
+                    Text("Notifications Disabled")
+                        .font(.headline)
+                    Text("Enable notifications anytime in Settings to get reminders.")
+                        .font(.subheadline)
+                        .multilineTextAlignment(.center)
+                    Button("OK") { showDeniedInfo = false }
+                        .padding(.top, 8)
+                }
+                .padding()
+                .presentationDetents([.medium])
+            }
         }
     }
 }

--- a/CouplesCount/Views/OnboardingView.swift
+++ b/CouplesCount/Views/OnboardingView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @EnvironmentObject private var theme: ThemeManager
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
+    /// Called when notification access is denied so the host can present guidance.
+    let onDenied: () -> Void
+
+    var body: some View {
+        TabView {
+            slide(image: "calendar.badge.plus", text: "Create & customize a countdown.")
+            slide(image: "bell", text: "Get reminders before your special day.")
+            finalSlide
+        }
+        .tabViewStyle(.page)
+        .background(theme.theme.background.ignoresSafeArea())
+        .tint(theme.theme.accent)
+    }
+
+    @ViewBuilder
+    private func slide(image: String, text: String) -> some View {
+        VStack {
+            Spacer()
+            Image(systemName: image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 120, height: 120)
+                .foregroundStyle(theme.theme.accent)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(.title2)
+                .multilineTextAlignment(.center)
+                .padding(.top, 24)
+                .padding(.horizontal)
+            Spacer()
+        }
+        .padding()
+    }
+
+    private var finalSlide: some View {
+        VStack {
+            Spacer()
+            Image(systemName: "heart.circle.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 120, height: 120)
+                .foregroundStyle(theme.theme.accent)
+                .accessibilityHidden(true)
+            Text("Share with your partner.")
+                .font(.title2)
+                .multilineTextAlignment(.center)
+                .padding(.top, 24)
+                .padding(.horizontal)
+            Button(action: finishOnboarding) {
+                Text("Done")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.accent))
+            }
+            .padding(.top, 32)
+            .padding(.horizontal)
+            Spacer()
+        }
+        .padding()
+    }
+
+    private func finishOnboarding() {
+        hasSeenOnboarding = true
+        NotificationManager.requestAuthorization { granted in
+            if !granted {
+                onDenied()
+            }
+        }
+    }
+}
+
+#Preview {
+    OnboardingView(onDenied: {})
+        .environmentObject(ThemeManager())
+}

--- a/Services/NotificationManager.swift
+++ b/Services/NotificationManager.swift
@@ -4,7 +4,7 @@ import UserNotifications
 enum NotificationManager {
     private static let defaultsKey = "notificationsAuthorized"
 
-    private static func requestAuthorization() {
+    static func requestAuthorization(completion: @escaping (Bool) -> Void) {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
             AppGroup.defaults.set(granted, forKey: defaultsKey)
             #if DEBUG
@@ -14,6 +14,9 @@ enum NotificationManager {
                 print("Notification authorization denied")
             }
             #endif
+            DispatchQueue.main.async {
+                completion(granted)
+            }
         }
     }
 
@@ -21,7 +24,7 @@ enum NotificationManager {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             switch settings.authorizationStatus {
             case .notDetermined:
-                requestAuthorization()
+                requestAuthorization { _ in }
             case .authorized:
                 AppGroup.defaults.set(true, forKey: defaultsKey)
             default:


### PR DESCRIPTION
## Summary
- Show three-step onboarding carousel only on first launch
- Add Done button on final slide that marks onboarding complete and requests notification permission
- Present a sheet with instructions if notifications are denied

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -version` *(fails: command not found)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa419cc3648333bd037c4f269fa432