### PR TITLE
Add support and legal resources to settings

### DIFF
--- a/CouplesCount/Views/AboutLegalView.swift
+++ b/CouplesCount/Views/AboutLegalView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct AboutLegalView: View {
+    @EnvironmentObject private var theme: ThemeManager
+    let privacyURL: URL
+    let termsURL: URL
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Text("Version")
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Build")
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section {
+                Link(destination: privacyURL) {
+                    Label("Privacy Policy", systemImage: "hand.raised.fill")
+                }
+                Link(destination: termsURL) {
+                    Label("Terms of Service", systemImage: "doc.text")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(theme.theme.background.ignoresSafeArea())
+        .tint(theme.theme.accent)
+        .navigationTitle("About & Legal")
+    }
+}


### PR DESCRIPTION
## Summary
- replace Settings layout with grouped list and top Support section
- add Legal section with Privacy Policy and About screen
- pre-fill support emails with app and iOS version details

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aa44a601548333bb39b8afdaf8840b