### PR TITLE
Ensure profile header respects notch

### DIFF
--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -79,6 +79,7 @@ struct ProfileView: View {
                     }
                 }
                 .padding(.horizontal)
+                .padding(.top, 12)
 
                 Text("Username")
                     .font(.title2)
@@ -143,6 +144,7 @@ struct ProfileView: View {
                 .animation(.spring(response: 0.4, dampingFraction: 0.85), value: shared)
             }
         }
+        .safeAreaPadding(.top)
         .background(theme.theme.background.ignoresSafeArea())
     }
 }


### PR DESCRIPTION
## Summary
- Prevent profile header from overlapping the notch by padding the top of the header and respecting the safe area

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aad599bb8083338b3fe4e353a6685a