### PR TITLE
Fix close button layout in Premium Promo view

### DIFF
--- a/CouplesCount/Views/PremiumPromoView.swift
+++ b/CouplesCount/Views/PremiumPromoView.swift
@@ -5,7 +5,7 @@ struct PremiumPromoView: View {
     @Binding var show: Bool
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack {
             theme.theme.background.ignoresSafeArea()
 
             VStack {
@@ -22,7 +22,8 @@ struct PremiumPromoView: View {
                     .padding()
                 Spacer()
             }
-
+        }
+        .safeAreaInset(edge: .top, alignment: .leading) {
             Button {
                 withAnimation(.spring()) { show = false }
             } label: {


### PR DESCRIPTION
## Summary
- Wrap PremiumPromoView close button in a safe area inset so it respects notch

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aad74d20808333a8d85501ac298d61