### PR TITLE
Use safe area insets for bottom padding

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -37,6 +37,7 @@ struct ContentView: View {
 struct CountdownListView: View {
     @EnvironmentObject private var theme: ThemeManager
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
 
     @Query(filter: #Predicate<Countdown> { !$0.isArchived },
            sort: \.targetUTC, order: .forward)
@@ -201,7 +202,7 @@ struct CountdownListView: View {
                             .foregroundStyle(.white)
                             .shadow(radius: 6, y: 3)
                     }
-                    .padding(.bottom, 24)
+                    .padding(.bottom, safeAreaInsets.bottom + 24)
                 }
                 .frame(maxWidth: .infinity) // centers horizontally
             }

--- a/CouplesCount/Views/CountdownDetailView.swift
+++ b/CouplesCount/Views/CountdownDetailView.swift
@@ -5,6 +5,7 @@ struct CountdownDetailView: View {
     @EnvironmentObject private var theme: ThemeManager
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
     let countdown: Countdown
 
     @State private var showShareSheet = false
@@ -37,7 +38,7 @@ struct CountdownDetailView: View {
                     .foregroundStyle(.secondary)
             }
             .padding(.horizontal)
-            .padding(.bottom, 40)
+            .padding(.bottom, safeAreaInsets.bottom + 40)
         }
         .background(theme.theme.background.ignoresSafeArea())
         .toolbar {
@@ -84,7 +85,7 @@ struct CountdownDetailView: View {
                     .background(.black.opacity(0.7))
                     .foregroundStyle(.white)
                     .cornerRadius(8)
-                    .padding(.bottom, 40)
+                    .padding(.bottom, safeAreaInsets.bottom + 40)
                     .transition(.opacity)
             }
         }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -5,6 +5,7 @@ import UIKit
 struct ProfileView: View {
     @EnvironmentObject private var theme: ThemeManager
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
     @Query(filter: #Predicate<Countdown> { $0.isShared && !$0.isArchived },
            sort: \Countdown.targetUTC, order: .forward)
     private var shared: [Countdown]
@@ -144,7 +145,7 @@ struct ProfileView: View {
                 .animation(.spring(response: 0.4, dampingFraction: 0.85), value: shared)
             }
         }
-        .safeAreaPadding(.top)
+        .padding(.top, safeAreaInsets.top)
         .background(theme.theme.background.ignoresSafeArea())
     }
 }


### PR DESCRIPTION
## Summary
- Read dynamic safe-area insets when positioning floating controls
- Pad detail view content, toast overlay, and profile screen using safe-area insets instead of fixed offsets

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aae492a56083338d90ca8c814044dd