### PR TITLE
Lock app to portrait orientation

### DIFF
--- a/CouplesCount/Info.plist
+++ b/CouplesCount/Info.plist
@@ -6,5 +6,13 @@
     <string>Allow access to your photo library to select a profile picture.</string>
     <key>NSCameraUsageDescription</key>
     <string>Allow access to the camera to take a profile picture.</string>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- force CouplesCount app to use portrait orientation only for iPhone and iPad by specifying UISupportedInterfaceOrientations

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1249f5548333872ed106e136d808