### PR TITLE
Lock app to portrait orientation

### DIFF
--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -1,8 +1,16 @@
 import SwiftUI
 import SwiftData
+import UIKit
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        .portrait
+    }
+}
 
 @main
 struct CouplesCountApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var theme = ThemeManager()
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     @State private var showDeniedInfo = false

--- a/CouplesCount/Info.plist
+++ b/CouplesCount/Info.plist
@@ -6,5 +6,13 @@
     <string>Allow access to your photo library to select a profile picture.</string>
     <key>NSCameraUsageDescription</key>
     <string>Allow access to the camera to take a profile picture.</string>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- force CouplesCount app to use portrait orientation only for iPhone and iPad by specifying UISupportedInterfaceOrientations
- enforce portrait lock via AppDelegate override of supportedInterfaceOrientations

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1249f5548333872ed106e136d808