### PR TITLE
Modernize for iOS 18 and refine UX

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -67,18 +67,28 @@ struct CountdownListView: View {
                                 showPremium = true
                             }
                         } label: {
-                            Image(systemName: "crown.fill").font(.title2)
+                            Image(systemName: "crown.fill")
+                                .font(.title2)
+                                .frame(width: 44, height: 44)
+                                .contentShape(Rectangle())
+                                .accessibilityLabel("Go Pro")
+                                .accessibilityHint("View premium features")
                         }
                         Spacer()
                         Text(Date.now, format: .dateTime.weekday(.wide).month().day())
-                            .font(.system(size: 28, weight: .semibold))
+                            .font(.system(size: FontMetrics(forTextStyle: .title).scaledValue(for: 28), weight: .semibold))
                         Spacer()
                         Button { showSettings = true } label: {
-                            Image(systemName: "gearshape.fill").font(.title2)
+                            Image(systemName: "gearshape.fill")
+                                .font(.title2)
+                                .frame(width: 44, height: 44)
+                                .contentShape(Rectangle())
+                                .accessibilityLabel("Settings")
+                                .accessibilityHint("Open settings")
                         }
                     }
                     .padding(.horizontal)
-                    .padding(.top, 12)
+                    .safeAreaPadding(.top, 12)
 
                     // List
                     if items.isEmpty {
@@ -154,12 +164,15 @@ struct CountdownListView: View {
                                             Haptics.warning()
                                         } label: {
                                             Image(systemName: "trash")
-                                                .font(.system(size: 16, weight: .bold))
-                                                .padding(12)
+                                                .font(.system(size: FontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
+                                                .frame(width: 44, height: 44)
                                                 .background(Circle().fill(Color.red))
                                                 .foregroundStyle(.white)
+                                                .accessibilityLabel("Delete")
+                                                .accessibilityHint("Remove countdown")
                                         }
                                         .tint(.clear)
+                                        .contentShape(Rectangle())
                                     }
                                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                         Button {
@@ -172,12 +185,15 @@ struct CountdownListView: View {
                                             if item.isArchived { Haptics.light() }
                                         } label: {
                                             Image(systemName: item.isArchived ? "arrow.uturn.backward" : "archivebox")
-                                                .font(.system(size: 16, weight: .bold))
-                                                .padding(12)
+                                                .font(.system(size: FontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
+                                                .frame(width: 44, height: 44)
                                                 .background(Circle().fill(Color.blue))
                                                 .foregroundStyle(.white)
+                                                .accessibilityLabel(item.isArchived ? "Unarchive" : "Archive")
+                                                .accessibilityHint(item.isArchived ? "Restore countdown" : "Archive countdown")
                                         }
                                         .tint(.clear)
+                                        .contentShape(Rectangle())
                                     }
                             }
                         }
@@ -209,8 +225,13 @@ struct CountdownListView: View {
                             .background(Circle().fill(.tint))
                             .foregroundStyle(.white)
                             .shadow(radius: 6, y: 3)
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
+                            .accessibilityLabel("Add countdown")
+                            .accessibilityHint("Create new countdown")
                     }
-                    .padding(.bottom, 24)
+                    .safeAreaPadding(.bottom)
+                    .padding(.bottom, 16)
 
                 }
                 .frame(maxWidth: .infinity) // centers horizontally

--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -1,16 +1,8 @@
 import SwiftUI
 import SwiftData
-import UIKit
-
-class AppDelegate: NSObject, UIApplicationDelegate {
-    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        .portrait
-    }
-}
 
 @main
 struct CouplesCountApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var pro: ProStatusProvider
     @StateObject private var theme: ThemeManager
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
@@ -57,7 +49,7 @@ struct CouplesCountApp: App {
                 .padding()
                 .presentationDetents([.medium])
             }
-            .onChange(of: pro.isPro) { newValue in
+            .onChange(of: pro.isProPublished, initial: false) { _, newValue in
                 if AppConfig.entitlementsMode == .live && !newValue {
                     theme.setTheme(.light)
                 }

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -191,6 +191,7 @@ struct AddEditCountdownView: View {
                                     .scaledToFill()
                                     .frame(height: 140)
                                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                    .accessibilityHidden(true)
                             } else {
                                 Text("No image selected")
                                     .foregroundStyle(.secondary)
@@ -334,10 +335,18 @@ struct AddEditCountdownView: View {
                                 showShareSheet = shareURL != nil
                             } label: {
                                 Image(systemName: "square.and.arrow.up")
+                                    .frame(width: 44, height: 44)
+                                    .contentShape(Rectangle())
+                                    .accessibilityLabel("Share")
+                                    .accessibilityHint("Share countdown")
                             }
                         }
                         Button(action: save) {
                             Image(systemName: "checkmark")
+                                .frame(width: 44, height: 44)
+                                .contentShape(Rectangle())
+                                .accessibilityLabel("Save")
+                                .accessibilityHint("Save countdown")
                         }
                         .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
@@ -351,10 +360,10 @@ struct AddEditCountdownView: View {
                 }
             }
             // Live preview & haptics
-            .onChange(of: title) { _, new in
+            .onChange(of: title, initial: false) { _, new in
                 previewTitle = new.isEmpty ? "Countdown" : new
             }
-            .onChange(of: date) { _, new in
+            .onChange(of: date, initial: false) { _, new in
                 previewDate = new
             }
             .onChange(of: colorHex, initial: false) { _, new in

--- a/CouplesCount/Views/Components/TreeGrowthView.swift
+++ b/CouplesCount/Views/Components/TreeGrowthView.swift
@@ -21,13 +21,14 @@ struct TreeGrowthView: View {
                     Text("🎉")
                         .font(.largeTitle)
                         .offset(y: -geo.size.height * 0.8)
+                        .accessibilityHidden(true)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .animation(.easeInOut(duration: 1.0), value: animated)
         }
         .onAppear { animated = progress }
-        .onChange(of: progress) { _, newValue in
+        .onChange(of: progress, initial: false) { _, newValue in
             animated = newValue
         }
     }

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -63,6 +63,7 @@ struct CountdownCardView: View {
                                 .resizable()
                                 .scaledToFill()
                                 .clipped()
+                                .accessibilityHidden(true)
                         }
                     }
                 )
@@ -94,15 +95,19 @@ struct CountdownCardView: View {
             HStack(spacing: 4) {
                 if shared {
                     Image(systemName: "person.2.fill")
+                        .accessibilityHidden(true)
                 }
                 if let shareAction {
                     Button(action: shareAction) {
                         Image(systemName: "square.and.arrow.up")
-                            .font(.system(size: 18, weight: .semibold))
-                            .padding(8)
+                            .font(.system(size: FontMetrics(forTextStyle: .body).scaledValue(for: 18), weight: .semibold))
+                            .frame(width: 44, height: 44)
                             .background(
                                 Circle().fill(Color.white.opacity(0.25))
                             )
+                            .contentShape(Rectangle())
+                            .accessibilityLabel("Share")
+                            .accessibilityHint("Share this countdown")
                     }
                     .buttonStyle(.plain)
                 }

--- a/CouplesCount/Views/CountdownDetailView.swift
+++ b/CouplesCount/Views/CountdownDetailView.swift
@@ -39,7 +39,7 @@ struct CountdownDetailView: View {
                     .foregroundStyle(.secondary)
             }
             .padding(.horizontal)
-            .padding(.bottom, 40)
+            .safeAreaPadding(.bottom, 40)
 
         }
         .background(theme.theme.background.ignoresSafeArea())
@@ -50,9 +50,17 @@ struct CountdownDetailView: View {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button(action: share) {
                     Image(systemName: "square.and.arrow.up")
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                        .accessibilityLabel("Share")
+                        .accessibilityHint("Share countdown")
                 }
                 Button(action: { showEdit = true }) {
                     Image(systemName: "pencil")
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                        .accessibilityLabel("Edit")
+                        .accessibilityHint("Edit countdown")
                 }
                 Menu {
                     Button(countdown.isArchived ? "Unarchive" : "Archive") {
@@ -61,6 +69,10 @@ struct CountdownDetailView: View {
                     Button("Delete", role: .destructive) { showDeleteAlert = true }
                 } label: {
                     Image(systemName: "ellipsis.circle")
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                        .accessibilityLabel("More options")
+                        .accessibilityHint("Show additional actions")
                 }
             }
         }
@@ -88,8 +100,7 @@ struct CountdownDetailView: View {
                     .background(.black.opacity(0.7))
                     .foregroundStyle(.white)
                     .cornerRadius(8)
-                    .padding(.bottom, 40)
-
+                    .safeAreaPadding(.bottom, 40)
                     .transition(.opacity)
             }
         }

--- a/CouplesCount/Views/PaywallView.swift
+++ b/CouplesCount/Views/PaywallView.swift
@@ -8,6 +8,7 @@ struct PaywallView: View {
             Image(systemName: "crown.fill")
                 .font(.largeTitle)
                 .foregroundStyle(.yellow)
+                .accessibilityHidden(true)
             Text("CouplesCount Pro")
                 .font(.title2.weight(.semibold))
             Text("Upgrade to unlock premium features.")

--- a/CouplesCount/Views/PremiumPromoView.swift
+++ b/CouplesCount/Views/PremiumPromoView.swift
@@ -11,8 +11,9 @@ struct PremiumPromoView: View {
             VStack {
                 Spacer()
                 Image(systemName: "crown.fill")
-                    .font(.system(size: 80))
+                    .font(.system(size: FontMetrics(forTextStyle: .largeTitle).scaledValue(for: 80)))
                     .foregroundStyle(theme.theme.accent)
+                    .accessibilityHidden(true)
                 Text("CouplesCount Premium")
                     .font(.largeTitle.bold())
                     .padding(.top, 12)
@@ -29,7 +30,10 @@ struct PremiumPromoView: View {
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.title2)
-                    .padding()
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+                    .accessibilityLabel("Close")
+                    .accessibilityHint("Dismiss premium promotion")
             }
         }
     }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -40,6 +40,8 @@ struct ProfileView: View {
                         .background(Color.gray.opacity(profileImageData == nil ? 0.2 : 0))
                         .clipShape(Circle())
                     }
+                    .accessibilityLabel("Profile photo")
+                    .accessibilityHint("Change your profile picture")
                     .buttonStyle(.plain)
                     .confirmationDialog("Profile Photo", isPresented: $showPhotoOptions) {
                         if UIImagePickerController.isSourceTypeAvailable(.camera) {
@@ -79,7 +81,7 @@ struct ProfileView: View {
                     }
                 }
                 .padding(.horizontal)
-                .padding(.top, 12)
+                .safeAreaPadding(.top, 12)
 
                 Text("Username")
                     .font(.title2)
@@ -144,7 +146,6 @@ struct ProfileView: View {
                 .animation(.spring(response: 0.4, dampingFraction: 0.85), value: shared)
             }
         }
-        .padding(.top)
         .background(theme.theme.background.ignoresSafeArea())
     }
 }

--- a/CouplesCount/Views/SettingsComponents.swift
+++ b/CouplesCount/Views/SettingsComponents.swift
@@ -66,11 +66,13 @@ struct ThemeSwatch: View {
                         .foregroundStyle(.white, theme.accent)
                         .padding(8)
                         .shadow(radius: 4, y: 2)
+                        .accessibilityHidden(true)
                 }
 
                 if isLocked {
                     HStack(spacing: 4) {
                         Image(systemName: "crown.fill")
+                            .accessibilityHidden(true)
                         Text("Pro")
                             .font(.caption2.weight(.semibold))
                     }

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -74,6 +74,7 @@ struct SettingsView: View {
                                           RoundedRectangle(cornerRadius: 8)
                                               .fill(theme.theme.accent)
                                       )
+                                      .accessibilityHidden(true)
                                   Text("Manage Archive")
                                       .font(.body)
                                   Spacer()
@@ -140,7 +141,7 @@ struct SettingsView: View {
         ) {
             Button("Yes") {
                 if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                    SKStoreReviewController.requestReview(in: scene)
+                    AppStore.requestReview(in: scene)
                 }
             }
             Button("No") { showFeedbackForm = true }
@@ -173,6 +174,7 @@ struct SettingsView: View {
                         RoundedRectangle(cornerRadius: 8)
                             .fill(theme.theme.accent)
                     )
+                    .accessibilityHidden(true)
                 Text(title).font(.body)
                 Spacer()
             }
@@ -244,12 +246,15 @@ struct ArchiveView: View {
                                     Haptics.warning()
                                 } label: {
                                     Image(systemName: "trash")
-                                        .font(.system(size: 16, weight: .bold))
-                                        .padding(12)
+                                        .font(.system(size: FontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
+                                        .frame(width: 44, height: 44)
                                         .background(Circle().fill(Color.red))
                                         .foregroundStyle(.white)
+                                        .accessibilityLabel("Delete")
+                                        .accessibilityHint("Remove countdown")
                                 }
                                 .tint(.clear)
+                                .contentShape(Rectangle())
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                 Button {
@@ -261,12 +266,15 @@ struct ArchiveView: View {
                                     }
                                 } label: {
                                     Image(systemName: "arrow.uturn.backward")
-                                        .font(.system(size: 16, weight: .bold))
-                                        .padding(12)
+                                        .font(.system(size: FontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
+                                        .frame(width: 44, height: 44)
                                         .background(Circle().fill(Color.blue))
                                         .foregroundStyle(.white)
+                                        .accessibilityLabel("Unarchive")
+                                        .accessibilityHint("Restore countdown")
                                 }
                                 .tint(.clear)
+                                .contentShape(Rectangle())
                             }
                         }
                     }

--- a/CouplesCount/Views/TimeZonePickerView.swift
+++ b/CouplesCount/Views/TimeZonePickerView.swift
@@ -12,6 +12,7 @@ struct TimeZonePickerView: View {
                 if id == selectedID {
                     Image(systemName: "checkmark")
                         .foregroundStyle(.tint)
+                        .accessibilityHidden(true)
                 }
             }
             .contentShape(Rectangle())

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -23,6 +23,7 @@ struct WidgetPreview: View {
                                 .scaledToFill()
                                 .clipped()
                                 .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                                .accessibilityHidden(true)
                         }
                     }
                 )

--- a/Shared/Entitlements/ProStatusProvider.swift
+++ b/Shared/Entitlements/ProStatusProvider.swift
@@ -1,15 +1,27 @@
 import Foundation
 import Combine
 
+@MainActor
 protocol ProStatusProviding {
     var isPro: Bool { get }
+    var isProPublished: Bool { get }
 }
 
 @MainActor
 final class ProStatusProvider: ObservableObject, ProStatusProviding {
 #if DEBUG
-    @Published var debugIsPro = false
+    @Published var debugIsPro = false {
+        didSet { isProPublished = isPro }
+    }
 #endif
+
+    @Published private(set) var isProPublished: Bool
+
+    init() {
+        isProPublished = false
+        isProPublished = isPro
+    }
+
     var isPro: Bool {
 #if DEBUG
         if debugIsPro { return true }


### PR DESCRIPTION
## Summary
- Replace deprecated APIs and actor-isolate Pro scaffolding with a publishable `isPro` flag.
- Adopt safe-area aware layouts, dynamic fonts, and accessible hit targets across views.
- Swap SKStoreReviewController for AppStore review requests.

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab186c460c83338df10d21111af766