### PR TITLE
Gate themes behind Pro and enforce light mode for free users

### DIFF
--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -11,10 +11,10 @@ struct CouplesCountApp: App {
     init() {
         let provider = ProStatusProvider()
         _pro = StateObject(wrappedValue: provider)
-        let themeManager = ThemeManager()
+        let themeManager = ThemeManager(pro: provider)
         _theme = StateObject(wrappedValue: themeManager)
         Entitlements.setProvider(provider)
-        if AppConfig.entitlementsMode == .live && !provider.isPro {
+        if themeManager.isStrictLight {
             themeManager.setTheme(.light)
         }
     }
@@ -49,11 +49,13 @@ struct CouplesCountApp: App {
                 .padding()
                 .presentationDetents([.medium])
             }
-            .onChange(of: pro.isProPublished, initial: false) { _, newValue in
-                if AppConfig.entitlementsMode == .live && !newValue {
+            .onChange(of: pro.isProPublished, initial: false) { _, _ in
+                theme.refreshStrictLight()
+                if theme.isStrictLight {
                     theme.setTheme(.light)
                 }
             }
+            .preferredColorScheme(theme.isStrictLight ? .light : nil)
         }
     }
 }

--- a/CouplesCount/Views/CountdownDetailView.swift
+++ b/CouplesCount/Views/CountdownDetailView.swift
@@ -212,5 +212,5 @@ struct CountdownDetailView: View {
 #Preview {
     let countdown = Countdown(title: "Preview", targetDate: .now.addingTimeInterval(3600), timeZoneID: TimeZone.current.identifier)
     return CountdownDetailView(countdown: countdown)
-        .environmentObject(ThemeManager())
+        .environmentObject(ThemeManager(pro: ProStatusProvider()))
 }

--- a/CouplesCount/Views/OnboardingView.swift
+++ b/CouplesCount/Views/OnboardingView.swift
@@ -78,5 +78,5 @@ struct OnboardingView: View {
 
 #Preview {
     OnboardingView(onDenied: {})
-        .environmentObject(ThemeManager())
+        .environmentObject(ThemeManager(pro: ProStatusProvider()))
 }

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -20,24 +20,26 @@ struct SettingsView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 18) {
-                    SettingsCard {
-                        LazyVGrid(
-                            columns: [GridItem(.flexible(), spacing: 12),
-                                      GridItem(.flexible(), spacing: 12)],
-                            spacing: 12
-                        ) {
-                            ForEach(themes, id: \.self) { t in
-                                let ent = Entitlements.current
-                                let locked = AppConfig.entitlementsMode == .live && ((t == .dark && !ent.hasDarkMode) || (t != .light && t != .dark && !ent.hasPremiumThemes))
-                                ThemeSwatch(theme: t, isSelected: t == theme.theme, isLocked: locked) {
-                                    if locked {
-                                        showPaywall = true
-                                    } else {
-                                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                        theme.setTheme(t)   // instant global update
+                    if !theme.isStrictLight {
+                        SettingsCard {
+                            LazyVGrid(
+                                columns: [GridItem(.flexible(), spacing: 12),
+                                          GridItem(.flexible(), spacing: 12)],
+                                spacing: 12
+                            ) {
+                                ForEach(themes, id: \.self) { t in
+                                    let ent = Entitlements.current
+                                    let locked = AppConfig.entitlementsMode == .live && ((t == .dark && !ent.hasDarkMode) || (t != .light && t != .dark && !ent.hasPremiumThemes))
+                                    ThemeSwatch(theme: t, isSelected: t == theme.theme, isLocked: locked) {
+                                        if locked {
+                                            showPaywall = true
+                                        } else {
+                                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                            theme.setTheme(t)   // instant global update
+                                        }
                                     }
+                                    .environmentObject(theme)
                                 }
-                                .environmentObject(theme)
                             }
                         }
                     }

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -9,6 +9,7 @@ struct WidgetPreview: View {
     let bgColorHex: String?
     let imageData: Data?
 
+    @EnvironmentObject private var theme: ThemeManager
     @State private var now = Date()
 
     var body: some View {
@@ -47,6 +48,7 @@ struct WidgetPreview: View {
             .padding()
         }
         .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }
+        .preferredColorScheme(theme.isStrictLight ? .light : nil)
     }
 
     private var backgroundFill: some ShapeStyle {

--- a/Shared/Theme/ThemeManager.swift
+++ b/Shared/Theme/ThemeManager.swift
@@ -5,12 +5,20 @@ import WidgetKit
 final class ThemeManager: ObservableObject {
     private let key = "global_color_theme"
     private let defaults = AppGroup.defaults
+    private let pro: ProStatusProviding
 
     @Published var theme: ColorTheme
+    @Published private(set) var isStrictLight: Bool
 
-    init() {
+    init(pro: ProStatusProviding) {
+        self.pro = pro
         let raw = defaults.string(forKey: key)
         self.theme = ColorTheme(rawOrDefault: raw)
+        self.isStrictLight = AppConfig.entitlementsMode == .live && !pro.isPro
+    }
+
+    func refreshStrictLight() {
+        isStrictLight = AppConfig.entitlementsMode == .live && !pro.isPro
     }
 
     // Update theme and notify widgets.


### PR DESCRIPTION
## Summary
- Add `isStrictLight` flag in `ThemeManager` to enforce light mode when app runs live without Pro
- Force app and widget preview to light mode and hide Settings theme picker during strict-light mode
- Update previews for new `ThemeManager` initializer

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20ef40f08333a9692c04df08c68e