### PR TITLE
Force light mode for non‑Pro users

### DIFF
--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -14,7 +14,7 @@ struct CouplesCountApp: App {
         let themeManager = ThemeManager()
         _theme = StateObject(wrappedValue: themeManager)
         Entitlements.setProvider(provider)
-        if AppConfig.entitlementsMode == .live && !provider.isPro {
+        if AppConfig.isStrictLight {
             themeManager.setTheme(.light)
         }
     }
@@ -54,6 +54,7 @@ struct CouplesCountApp: App {
                     theme.setTheme(.light)
                 }
             }
+            .preferredColorScheme(AppConfig.isStrictLight ? .light : nil)
         }
     }
 }

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -20,24 +20,26 @@ struct SettingsView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 18) {
-                    SettingsCard {
-                        LazyVGrid(
-                            columns: [GridItem(.flexible(), spacing: 12),
-                                      GridItem(.flexible(), spacing: 12)],
-                            spacing: 12
-                        ) {
-                            ForEach(themes, id: \.self) { t in
-                                let ent = Entitlements.current
-                                let locked = AppConfig.entitlementsMode == .live && ((t == .dark && !ent.hasDarkMode) || (t != .light && t != .dark && !ent.hasPremiumThemes))
-                                ThemeSwatch(theme: t, isSelected: t == theme.theme, isLocked: locked) {
-                                    if locked {
-                                        showPaywall = true
-                                    } else {
-                                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                        theme.setTheme(t)   // instant global update
+                    if !AppConfig.isStrictLight {
+                        SettingsCard {
+                            LazyVGrid(
+                                columns: [GridItem(.flexible(), spacing: 12),
+                                          GridItem(.flexible(), spacing: 12)],
+                                spacing: 12
+                            ) {
+                                ForEach(themes, id: \.self) { t in
+                                    let ent = Entitlements.current
+                                    let locked = AppConfig.entitlementsMode == .live && ((t == .dark && !ent.hasDarkMode) || (t != .light && t != .dark && !ent.hasPremiumThemes))
+                                    ThemeSwatch(theme: t, isSelected: t == theme.theme, isLocked: locked) {
+                                        if locked {
+                                            showPaywall = true
+                                        } else {
+                                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                            theme.setTheme(t)   // instant global update
+                                        }
                                     }
+                                    .environmentObject(theme)
                                 }
-                                .environmentObject(theme)
                             }
                         }
                     }

--- a/Shared/Entitlements/AppConfig.swift
+++ b/Shared/Entitlements/AppConfig.swift
@@ -8,6 +8,10 @@ enum AppEntitlementsMode {
 enum AppConfig {
     // Flip this one line later to enable live gating
     static var entitlementsMode: AppEntitlementsMode = .freeForAll
+
+    static var isStrictLight: Bool {
+        entitlementsMode == .live && !Entitlements.current.isPro
+    }
 }
 
 enum AppLimits {

--- a/Shared/Entitlements/Entitlements.swift
+++ b/Shared/Entitlements/Entitlements.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 struct Entitlements {
+    let isPro: Bool
     let isUnlimited: Bool
     let hasPremiumThemes: Bool
     let hasDarkMode: Bool
@@ -12,6 +13,7 @@ struct Entitlements {
     @MainActor
     init(provider: ProStatusProviding) {
         let pro = provider.isPro
+        isPro = pro
         isUnlimited = pro
         hasPremiumThemes = pro
         hasDarkMode = pro


### PR DESCRIPTION
## Summary
- add `isPro` flag and `isStrictLight` helper for entitlements
- force light color scheme and theme when non‑Pro
- hide theme picker for free users while keeping countdown customization

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2bb481b48333b09c6abf4e20e748