### PR TITLE
Refresh light theme with bright cards

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -228,7 +228,7 @@ struct CountdownListView: View {
                             .padding(20)
                             .background(Circle().fill(.tint))
                             .foregroundStyle(.white)
-                            .shadow(radius: 6, y: 3)
+                            .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
                             .frame(minWidth: 44, minHeight: 44)
                             .contentShape(Rectangle())
                             .accessibilityLabel("Add countdown")

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -49,7 +49,7 @@ struct AddEditCountdownView: View {
 
     // Background selection
     @State private var backgroundStyle: String = "color" // "color" | "image"
-    @State private var colorHex: String = "#0A84FF"
+    @State private var colorHex: String = "#FFFFFF"
     @State private var imageData: Data? = nil
     @State private var showPhotoPicker = false
     @State private var showCamera = false
@@ -57,7 +57,7 @@ struct AddEditCountdownView: View {
     // Live preview values
     @State private var previewTitle: String = "Countdown"
     @State private var previewDate: Date = Date().addingTimeInterval(86_400)
-    @State private var previewColorHex: String = "#0A84FF"
+    @State private var previewColorHex: String = "#FFFFFF"
     @State private var previewImageData: Data? = nil
 
     // Reminders

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -50,6 +50,16 @@ struct CountdownCardView: View {
     private let corner: CGFloat = 22
     @State private var now = Date()
 
+    private var isDefaultBackground: Bool {
+        if backgroundStyle == "image" { return false }
+        let hex = colorHex?.uppercased() ?? ""
+        return hex == "" || hex == "#FFFFFF"
+    }
+
+    private var primaryText: Color { isDefaultBackground ? .black : .white }
+    private var secondaryText: Color { isDefaultBackground ? .black.opacity(0.7) : .white.opacity(0.95) }
+    private var shareButtonBg: Color { isDefaultBackground ? .black.opacity(0.05) : .white.opacity(0.25) }
+
     var body: some View {
         ZStack(alignment: .leading) {
             // Background color or image
@@ -70,9 +80,8 @@ struct CountdownCardView: View {
                 )
                 .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
                 .overlay(
-                    // tiny inner highlight
                     RoundedRectangle(cornerRadius: corner, style: .continuous)
-                        .stroke(.white.opacity(0.06), lineWidth: 1)
+                        .stroke(isDefaultBackground ? .black.opacity(0.25) : .white.opacity(0.06), lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.15), radius: 10, y: 6)
 
@@ -81,16 +90,17 @@ struct CountdownCardView: View {
                 Text(title)
                     .font(CardTypography.font(for: fontStyle, role: .title))
                     .lineLimit(1)
+                    .foregroundStyle(primaryText)
 
                 Text(DateUtils.remainingText(to: targetDate, from: now, in: timeZoneID))
                     .font(CardTypography.font(for: fontStyle, role: .number))
+                    .foregroundStyle(primaryText)
 
                 Text(dateText)
                     .font(CardTypography.font(for: fontStyle, role: .date))
-                    .opacity(0.95)
+                    .foregroundStyle(secondaryText)
             }
             .padding(18)
-            .foregroundStyle(.white)
         }
         .overlay(alignment: .topTrailing) {
             HStack(spacing: 4) {
@@ -105,7 +115,7 @@ struct CountdownCardView: View {
 
                             .frame(width: 44, height: 44)
                             .background(
-                                Circle().fill(Color.white.opacity(0.25))
+                                Circle().fill(shareButtonBg)
                             )
                             .contentShape(Rectangle())
                             .accessibilityLabel("Share")
@@ -115,7 +125,7 @@ struct CountdownCardView: View {
                 }
             }
             .padding(8)
-            .foregroundStyle(.white)
+            .foregroundStyle(primaryText)
         }
         .frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
         .saturation(archived ? 0 : 1)
@@ -126,11 +136,10 @@ struct CountdownCardView: View {
         .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }
     }
 
-    private var accent: Color { theme.theme.accent }
-
     private var backgroundFill: some ShapeStyle {
         if backgroundStyle == "color",
-           let hex = colorHex,
+           let hex = colorHex?.uppercased(),
+           hex != "#FFFFFF",
            let c = Color(hex: hex) {
             return AnyShapeStyle(
                 LinearGradient(colors: [c, c.opacity(0.75)],
@@ -138,10 +147,6 @@ struct CountdownCardView: View {
                                endPoint: .bottomTrailing)
             )
         }
-        return AnyShapeStyle(
-            LinearGradient(colors: [accent, accent.opacity(0.75)],
-                           startPoint: .topLeading,
-                           endPoint: .bottomTrailing)
-        )
+        return AnyShapeStyle(Color.white)
     }
 }

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -11,6 +11,15 @@ struct WidgetPreview: View {
 
     @State private var now = Date()
 
+    private var isDefaultBackground: Bool {
+        if backgroundStyle == "image" { return false }
+        let hex = bgColorHex?.uppercased() ?? ""
+        return hex == "" || hex == "#FFFFFF"
+    }
+
+    private var primaryText: Color { isDefaultBackground ? .black : .white }
+    private var secondaryText: Color { isDefaultBackground ? .black.opacity(0.7) : .white.opacity(0.9) }
+
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 22, style: .continuous)
@@ -27,32 +36,36 @@ struct WidgetPreview: View {
                         }
                     }
                 )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .stroke(isDefaultBackground ? .black.opacity(0.25) : .white.opacity(0.06), lineWidth: 1)
+                )
                 .frame(height: 140)
 
             VStack(spacing: 6) {
                 Text(title)
                     .font(CardTypography.font(for: style, role: .title))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(primaryText)
                     .lineLimit(1)
 
                 Text(DateUtils.remainingText(to: targetDate, from: now, in: tzID))
                     .font(CardTypography.font(for: style, role: .number))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(primaryText)
 
                 Text(targetDate, style: .date)
                     .font(CardTypography.font(for: style, role: .date))
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundStyle(secondaryText)
             }
-            .shadow(color: .black.opacity(0.3), radius: 6, y: 3)
+            .shadow(color: isDefaultBackground ? .black.opacity(0.1) : .black.opacity(0.3), radius: 6, y: 3)
             .padding()
         }
         .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }
     }
 
     private var backgroundFill: some ShapeStyle {
-        if backgroundStyle == "color", let hex = bgColorHex, let c = Color(hex: hex) {
+        if backgroundStyle == "color", let hex = bgColorHex?.uppercased(), hex != "#FFFFFF", let c = Color(hex: hex) {
             return AnyShapeStyle(LinearGradient(colors: [c, c.opacity(0.8)], startPoint: .topLeading, endPoint: .bottomTrailing))
         }
-        return AnyShapeStyle(.black.opacity(0.25))
+        return AnyShapeStyle(Color.white)
     }
 }

--- a/Shared/Models/Countdown.swift
+++ b/Shared/Models/Countdown.swift
@@ -56,7 +56,7 @@ final class Countdown {
          isArchived: Bool = false,
          cardFontStyle: CardFontStyle = .classic,
          backgroundStyle: String = "color",
-         backgroundColorHex: String? = "#0A84FF",
+         backgroundColorHex: String? = "#FFFFFF",
          backgroundImageData: Data? = nil,
          reminderOffsets: [Int] = [],
          isShared: Bool = false,
@@ -66,7 +66,7 @@ final class Countdown {
         self.targetUTC = targetDate
         self.timeZoneID = timeZoneID
         self.includeTime = true
-        self.colorTheme = backgroundColorHex ?? "#0A84FF"
+        self.colorTheme = backgroundColorHex ?? "#FFFFFF"
         self.hasImage = backgroundStyle == "image"
         self.imageData = backgroundImageData
         self.cardFontStyleRaw = cardFontStyle.rawValue

--- a/Shared/Theme/ColorTheme.swift
+++ b/Shared/Theme/ColorTheme.swift
@@ -21,7 +21,7 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
 
     var background: Color {
         switch self {
-        case .light: Color(.systemBackground)
+        case .light: Color(red: 0.867, green: 0.933, blue: 0.996)
         case .dark: Color(.secondarySystemBackground)
         case .royalBlues: Color(red: 0.08, green: 0.19, blue: 0.45)
         case .barbie: Color(red: 0.98, green: 0.36, blue: 0.72)


### PR DESCRIPTION
## Summary
- Switch light mode background to a soft baby blue
- Default countdown cards render with white fill, dark outline and text, while custom colors/images still apply
- Widget preview and add button styling updated for the new light look

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2fc53c5083339c8dfb670b055652