### PR TITLE
Reduce top spacing and thicken countdown card border

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -203,7 +203,7 @@ struct CountdownListView: View {
                         }
                         .listStyle(.plain)
                         .listRowSpacing(16)
-                        .padding(.top, 28)
+                        .padding(.top, 8)
                         .scrollContentBackground(.hidden)
                         .animation(.spring(response: 0.4, dampingFraction: 0.85), value: items)
                     }

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -81,7 +81,7 @@ struct CountdownCardView: View {
                 .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: corner, style: .continuous)
-                        .stroke(Color.black.opacity(0.25), lineWidth: 1)
+                        .stroke(Color.black.opacity(0.25), lineWidth: 4)
 
                 )
                 .shadow(color: .black.opacity(0.15), radius: 10, y: 6)


### PR DESCRIPTION
## Summary
- Trim excess top padding above countdown list to prevent overlap with header
- Increase countdown card border width for a more prominent outline

## Testing
- `swiftc -typecheck CouplesCount/ContentView.swift CouplesCount/Views/CountdownCardView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68ab3da878308333b75d5095e446e27d