### PR TITLE
Improve countdown list spacing and add pull-to-refresh

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -55,6 +55,8 @@ struct CountdownListView: View {
     @State private var pressingID: UUID? = nil
     @State private var showPaywall = false
 
+    var refreshAction: (() async -> Void)? = nil
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -203,8 +205,11 @@ struct CountdownListView: View {
                         }
                         .listStyle(.plain)
                         .listRowSpacing(16)
-                        .padding(.top, 28)
+                        .safeAreaInset(edge: .top) {
+                            Color.clear.frame(height: 8)
+                        }
                         .scrollContentBackground(.hidden)
+                        .refreshable { await refreshAction?() }
                         .animation(.spring(response: 0.4, dampingFraction: 0.85), value: items)
                     }
                     if !Entitlements.current.hidesAds {

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -81,7 +81,7 @@ struct CountdownCardView: View {
                 .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: corner, style: .continuous)
-                        .stroke(Color.black.opacity(0.25), lineWidth: 1)
+                        .stroke(Color.black.opacity(0.25), lineWidth: 4)
 
                 )
                 .shadow(color: .black.opacity(0.15), radius: 10, y: 6)


### PR DESCRIPTION
## Summary
- Push countdown list lower so header no longer overlaps first card
- Expose optional refresh action and hook it up to pull-to-refresh
- Thicken countdown card border for clearer separation

## Testing
- `swiftc -typecheck CouplesCount/ContentView.swift CouplesCount/Views/CountdownCardView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68ab3da878308333b75d5095e446e27d