### PR TITLE
Adopt semantic light theme

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
                     Label("Profile", systemImage: "person.crop.circle")
                 }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
         .onOpenURL { url in
             do {
                 try CountdownShareService.importCountdown(from: url, context: modelContext)
@@ -60,7 +60,7 @@ struct CountdownListView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                theme.theme.background.ignoresSafeArea()
+                theme.theme.backgroundGradient.ignoresSafeArea()
 
                 VStack(spacing: 0) {
                     // Top bar
@@ -193,7 +193,7 @@ struct CountdownListView: View {
                                                 .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
 
                                                 .frame(width: 44, height: 44)
-                                                .background(Circle().fill(Color.blue))
+                                                .background(Circle().fill(theme.theme.accent))
                                                 .foregroundStyle(.white)
                                                 .accessibilityLabel(item.isArchived ? "Unarchive" : "Archive")
                                                 .accessibilityHint(item.isArchived ? "Restore countdown" : "Archive countdown")
@@ -234,7 +234,7 @@ struct CountdownListView: View {
                             .padding(20)
                             .background(Circle().fill(.tint))
                             .foregroundStyle(.white)
-                            .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
+                            .shadow(color: theme.theme.textPrimary.opacity(0.2), radius: 4, y: 2)
                             .frame(minWidth: 44, minHeight: 44)
                             .contentShape(Rectangle())
                             .accessibilityLabel("Add countdown")
@@ -278,6 +278,6 @@ struct CountdownListView: View {
                 PaywallView().environmentObject(theme)
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
     }
 }

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -168,9 +168,11 @@ struct AddEditCountdownView: View {
 
                         if backgroundStyle == "color" {
                             HStack(spacing: 10) {
-                                ForEach(["#0A84FF","#5856D6","#FF2D55","#34C759","#FF9F0A"], id: \.self) { hex in
+                                let swatches: [Color] = [theme.theme.primary, theme.theme.accent, theme.theme.background]
+                                ForEach(swatches, id: \.self) { color in
+                                    let hex = color.hexString
                                     Circle()
-                                        .fill(Color(hex: hex) ?? .blue)
+                                        .fill(color)
                                         .frame(width: 32, height: 32)
                                         .overlay(
                                             Circle().stroke(Color.white.opacity(colorHex == hex ? 0.9 : 0), lineWidth: 2)
@@ -179,7 +181,7 @@ struct AddEditCountdownView: View {
                                 }
                                 Spacer()
                                 ColorPicker("", selection: Binding(
-                                    get: { Color(hex: colorHex) ?? .blue },
+                                    get: { Color(hex: colorHex) ?? theme.theme.primary },
                                     set: { colorHex = $0.hexString }
                                 ))
                                 .labelsHidden()
@@ -254,7 +256,7 @@ struct AddEditCountdownView: View {
                                     }
                                     .padding(.horizontal, 8)
                                     .padding(.vertical, 4)
-                                    .background(Color(.systemGray5))
+                                    .background(theme.theme.background)
                                     .clipShape(Capsule())
                                 }
                             }
@@ -263,6 +265,7 @@ struct AddEditCountdownView: View {
                     }
                     .sheet(isPresented: $showReminderSheet) {
                         ReminderPicker(selections: $selectedReminders)
+                            .environmentObject(theme)
                     }
 
                     if showValidation && title.trimmingCharacters(in: .whitespaces).isEmpty {
@@ -314,13 +317,13 @@ struct AddEditCountdownView: View {
             .scrollIndicators(.hidden)
             .overlay(alignment: .trailing) {
                 RoundedRectangle(cornerRadius: 3)
-                    .fill(.gray.opacity(0.4))
+                    .fill(theme.theme.textTertiary)
                     .frame(width: 6)
                     .padding(.vertical, 8)
                     .padding(.trailing, 2)
             }
-            .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.accent)
+            .background(theme.theme.backgroundGradient.ignoresSafeArea())
+            .tint(theme.theme.primary)
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -399,7 +402,7 @@ struct AddEditCountdownView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
         .alert("Couldn’t Save",
                isPresented: Binding(get: { saveError != nil },
                                    set: { if !$0 { saveError = nil } })) {
@@ -478,6 +481,7 @@ struct ReminderPicker: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var selections: Set<ReminderOption>
     @State private var temp: Set<ReminderOption>
+    @EnvironmentObject private var theme: ThemeManager
 
     init(selections: Binding<Set<ReminderOption>>) {
         self._selections = selections
@@ -492,11 +496,11 @@ struct ReminderPicker: View {
                         let isSel = temp.contains(option)
                         Text(option.label)
                             .frame(maxWidth: .infinity, minHeight: 44)
-                            .background(isSel ? Color.accentColor.opacity(0.2) : Color(.systemGray5))
+                            .background(isSel ? theme.theme.primary.opacity(0.2) : theme.theme.background)
                             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 8)
-                                    .stroke(isSel ? Color.accentColor : .clear, lineWidth: 2)
+                                    .stroke(isSel ? theme.theme.primary : .clear, lineWidth: 2)
                             )
                             .onTapGesture {
                                 if isSel { temp.remove(option) } else { temp.insert(option) }

--- a/CouplesCount/Views/Components/AdBannerPlaceholderView.swift
+++ b/CouplesCount/Views/Components/AdBannerPlaceholderView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct AdBannerPlaceholderView: View {
     var body: some View {
         Rectangle()
-            .fill(Color.gray.opacity(0.2))
+            .fill(ColorTheme.default.textPrimary.opacity(0.2))
             .frame(height: 50)
             .overlay(
                 Text("Ad Banner")

--- a/CouplesCount/Views/Components/TreeGrowthView.swift
+++ b/CouplesCount/Views/Components/TreeGrowthView.swift
@@ -2,17 +2,18 @@ import SwiftUI
 
 struct TreeGrowthView: View {
     var progress: Double
+    @EnvironmentObject private var theme: ThemeManager
     @State private var animated: Double = 0
 
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .bottom) {
                 Rectangle()
-                    .fill(Color.brown)
+                    .fill(theme.theme.textPrimary)
                     .frame(width: geo.size.width * 0.1,
                            height: geo.size.height * CGFloat(animated))
                 Circle()
-                    .fill(Color.green)
+                    .fill(theme.theme.accent)
                     .frame(width: geo.size.width * 0.6,
                            height: geo.size.width * 0.6)
                     .scaleEffect(animated)

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -56,9 +56,9 @@ struct CountdownCardView: View {
         return hex == "" || hex == "#FFFFFF"
     }
 
-    private var primaryText: Color { isDefaultBackground ? .black : .white }
-    private var secondaryText: Color { isDefaultBackground ? .black.opacity(0.7) : .white.opacity(0.95) }
-    private var shareButtonBg: Color { isDefaultBackground ? .black.opacity(0.05) : .white.opacity(0.25) }
+    private var titleColor: Color { isDefaultBackground ? theme.theme.textPrimary : .white }
+    private var metaColor: Color { isDefaultBackground ? theme.theme.textSecondary : .white.opacity(0.9) }
+    private var shareButtonBg: Color { isDefaultBackground ? theme.theme.textPrimary.opacity(0.05) : Color.white.opacity(0.25) }
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -78,28 +78,35 @@ struct CountdownCardView: View {
                         }
                     }
                 )
+                .overlay {
+                    if backgroundStyle == "image" && imageData != nil {
+                        LinearGradient(colors: [theme.theme.textPrimary.opacity(0.35), .clear],
+                                       startPoint: .top,
+                                       endPoint: .center)
+                            .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+                    }
+                }
                 .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: corner, style: .continuous)
-                        .stroke(Color.black.opacity(0.25), lineWidth: 4)
-
+                        .stroke(theme.theme.outline, lineWidth: 1)
                 )
-                .shadow(color: .black.opacity(0.15), radius: 10, y: 6)
+                .shadow(color: theme.theme.textPrimary.opacity(0.1), radius: 4, y: 2)
 
             // Content
             VStack(alignment: .leading, spacing: 8) {
                 Text(title)
                     .font(CardTypography.font(for: fontStyle, role: .title))
                     .lineLimit(1)
-                    .foregroundStyle(primaryText)
+                    .foregroundStyle(titleColor)
 
                 Text(DateUtils.remainingText(to: targetDate, from: now, in: timeZoneID))
                     .font(CardTypography.font(for: fontStyle, role: .number))
-                    .foregroundStyle(primaryText)
+                    .foregroundStyle(theme.theme.primary)
 
                 Text(dateText)
                     .font(CardTypography.font(for: fontStyle, role: .date))
-                    .foregroundStyle(secondaryText)
+                    .foregroundStyle(metaColor)
             }
             .padding(18)
         }
@@ -126,7 +133,7 @@ struct CountdownCardView: View {
                 }
             }
             .padding(8)
-            .foregroundStyle(primaryText)
+            .foregroundStyle(titleColor)
         }
         .frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
         .saturation(archived ? 0 : 1)
@@ -148,6 +155,6 @@ struct CountdownCardView: View {
                                endPoint: .bottomTrailing)
             )
         }
-        return AnyShapeStyle(Color.white)
+        return AnyShapeStyle(theme.theme.backgroundGradient)
     }
 }

--- a/CouplesCount/Views/CountdownDetailView.swift
+++ b/CouplesCount/Views/CountdownDetailView.swift
@@ -28,6 +28,7 @@ struct CountdownDetailView: View {
                 info
                 sharedSection
                 TreeGrowthView(progress: progress)
+                    .environmentObject(theme)
                     .frame(height: 180)
                 Button("Remind me to check in") {
                     NotificationManager.scheduleCheckInReminder()
@@ -42,7 +43,7 @@ struct CountdownDetailView: View {
             .safeAreaPadding(.bottom, 40)
 
         }
-        .background(theme.theme.background.ignoresSafeArea())
+        .background(theme.theme.backgroundGradient.ignoresSafeArea())
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Close") { dismiss() }
@@ -97,7 +98,7 @@ struct CountdownDetailView: View {
             if showPokeToast {
                 Text(toastMessage)
                     .padding()
-                    .background(.black.opacity(0.7))
+                    .background(theme.theme.textPrimary.opacity(0.7))
                     .foregroundStyle(.white)
                     .cornerRadius(8)
                     .safeAreaPadding(.bottom, 40)

--- a/CouplesCount/Views/FeedbackFormView.swift
+++ b/CouplesCount/Views/FeedbackFormView.swift
@@ -18,14 +18,14 @@ struct FeedbackFormView: View {
                     .frame(height: 120)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(.secondary.opacity(0.2))
+                            .stroke(theme.theme.outline)
                     )
 
                 HStack {
                     ForEach(1...5, id: \.self) { index in
                         Image(systemName: index <= rating ? "star.fill" : "star")
                             .font(.title)
-                            .foregroundStyle(.yellow)
+                            .foregroundStyle(theme.theme.accent)
                             .onTapGesture { rating = index }
                     }
                 }
@@ -49,7 +49,8 @@ struct FeedbackFormView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .background(theme.theme.backgroundGradient.ignoresSafeArea())
+        .tint(theme.theme.primary)
     }
 }
 

--- a/CouplesCount/Views/OnboardingView.swift
+++ b/CouplesCount/Views/OnboardingView.swift
@@ -13,8 +13,8 @@ struct OnboardingView: View {
             finalSlide
         }
         .tabViewStyle(.page)
-        .background(theme.theme.background.ignoresSafeArea())
-        .tint(theme.theme.accent)
+        .background(theme.theme.backgroundGradient.ignoresSafeArea())
+        .tint(theme.theme.primary)
     }
 
     @ViewBuilder
@@ -57,7 +57,7 @@ struct OnboardingView: View {
                     .foregroundStyle(.white)
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.accent))
+                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.primary))
             }
             .padding(.top, 32)
             .padding(.horizontal)

--- a/CouplesCount/Views/PaywallView.swift
+++ b/CouplesCount/Views/PaywallView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 
 struct PaywallView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var theme: ThemeManager
 
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "crown.fill")
                 .font(.largeTitle)
-                .foregroundStyle(.yellow)
+                .foregroundStyle(theme.theme.accent)
                 .accessibilityHidden(true)
             Text("CouplesCount Pro")
                 .font(.title2.weight(.semibold))
@@ -19,5 +20,7 @@ struct PaywallView: View {
                 .padding(.top, 8)
         }
         .padding()
+        .background(theme.theme.backgroundGradient.ignoresSafeArea())
+        .tint(theme.theme.primary)
     }
 }

--- a/CouplesCount/Views/PremiumPromoView.swift
+++ b/CouplesCount/Views/PremiumPromoView.swift
@@ -7,7 +7,7 @@ struct PremiumPromoView: View {
 
     var body: some View {
         ZStack {
-            theme.theme.background.ignoresSafeArea()
+            theme.theme.backgroundGradient.ignoresSafeArea()
 
             VStack {
                 Spacer()

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -32,12 +32,12 @@ struct ProfileView: View {
                                 Image(systemName: "person.crop.circle.fill")
                                     .resizable()
                                     .scaledToFit()
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(theme.theme.textTertiary)
                                     .padding(4)
                             }
                         }
                         .frame(width: 80, height: 80)
-                        .background(Color.gray.opacity(profileImageData == nil ? 0.2 : 0))
+                        .background(theme.theme.textPrimary.opacity(profileImageData == nil ? 0.2 : 0))
                         .clipShape(Circle())
                     }
                     .accessibilityLabel("Profile photo")
@@ -146,6 +146,6 @@ struct ProfileView: View {
                 .animation(.spring(response: 0.4, dampingFraction: 0.85), value: shared)
             }
         }
-        .background(theme.theme.background.ignoresSafeArea())
+        .background(theme.theme.backgroundGradient.ignoresSafeArea())
     }
 }

--- a/CouplesCount/Views/SettingsComponents.swift
+++ b/CouplesCount/Views/SettingsComponents.swift
@@ -20,7 +20,7 @@ struct SettingsCard<Content: View>: View {
                             .stroke(.white.opacity(0.08), lineWidth: 1)
                     )
             )
-            .shadow(color: .black.opacity(0.12), radius: 12, y: 6)
+            .shadow(color: theme.theme.textPrimary.opacity(0.12), radius: 12, y: 6)
             .padding(.horizontal, 16)
     }
 }
@@ -76,7 +76,7 @@ struct ThemeSwatch: View {
                         Text("Pro")
                             .font(.caption2.weight(.semibold))
                     }
-                    .foregroundStyle(.yellow)
+                    .foregroundStyle(theme.accent)
                     .padding(6)
                     .background(.ultraThinMaterial)
                     .clipShape(Capsule())
@@ -87,7 +87,7 @@ struct ThemeSwatch: View {
                     HStack(spacing: 8) {
                         Circle().fill(theme.accent).frame(width: 10, height: 10)
                         Circle().fill(.white.opacity(0.85)).frame(width: 10, height: 10)
-                        Circle().fill(.black.opacity(0.6)).frame(width: 10, height: 10)
+                        Circle().fill(ColorTheme.default.textPrimary.opacity(0.6)).frame(width: 10, height: 10)
                     }
                     .padding(.top, 12)
 

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -9,7 +9,7 @@ struct SettingsView: View {
     @EnvironmentObject private var theme: ThemeManager
     @EnvironmentObject private var pro: ProStatusProvider
 
-    private let themes: [ColorTheme] = [.light, .dark, .royalBlues, .barbie, .lucky]
+    private let themes: [ColorTheme] = [.light]
     private let supportEmail = "support@couplescount.app"
     @State private var activeAlert: ActiveAlert?
     @State private var showEnjoyPrompt = false
@@ -118,8 +118,8 @@ struct SettingsView: View {
                 }
                 .padding(.top, 8)
             }
-            .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.accent)            // accent flows everywhere
+            .background(theme.theme.backgroundGradient.ignoresSafeArea())
+            .tint(theme.theme.primary)            // accent flows everywhere
             .scrollIndicators(.hidden)
             .navigationTitle("Settings")
             .toolbar {
@@ -208,7 +208,7 @@ struct ArchiveView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                theme.theme.background.ignoresSafeArea()
+                theme.theme.backgroundGradient.ignoresSafeArea()
 
                 if items.isEmpty {
                     VStack(spacing: 8) {
@@ -272,7 +272,7 @@ struct ArchiveView: View {
                                         .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
 
                                         .frame(width: 44, height: 44)
-                                        .background(Circle().fill(Color.blue))
+                                        .background(Circle().fill(theme.theme.accent))
                                         .foregroundStyle(.white)
                                         .accessibilityLabel("Unarchive")
                                         .accessibilityHint("Restore countdown")
@@ -295,7 +295,7 @@ struct ArchiveView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
     }
 }
 

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -17,8 +17,8 @@ struct WidgetPreview: View {
         return hex == "" || hex == "#FFFFFF"
     }
 
-    private var primaryText: Color { isDefaultBackground ? .black : .white }
-    private var secondaryText: Color { isDefaultBackground ? .black.opacity(0.7) : .white.opacity(0.9) }
+    private var titleColor: Color { isDefaultBackground ? ColorTheme.default.textPrimary : .white }
+    private var metaColor: Color { isDefaultBackground ? ColorTheme.default.textSecondary : .white.opacity(0.9) }
 
     var body: some View {
         ZStack {
@@ -36,28 +36,28 @@ struct WidgetPreview: View {
                         }
                     }
                 )
+                .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 22, style: .continuous)
-                        .stroke(Color.black.opacity(0.25), lineWidth: 1)
-
+                        .stroke(ColorTheme.default.outline, lineWidth: 1)
                 )
                 .frame(height: 140)
 
             VStack(spacing: 6) {
                 Text(title)
                     .font(CardTypography.font(for: style, role: .title))
-                    .foregroundStyle(primaryText)
+                    .foregroundStyle(titleColor)
                     .lineLimit(1)
 
                 Text(DateUtils.remainingText(to: targetDate, from: now, in: tzID))
                     .font(CardTypography.font(for: style, role: .number))
-                    .foregroundStyle(primaryText)
+                    .foregroundStyle(ColorTheme.default.primary)
 
                 Text(targetDate, style: .date)
                     .font(CardTypography.font(for: style, role: .date))
-                    .foregroundStyle(secondaryText)
+                    .foregroundStyle(metaColor)
             }
-            .shadow(color: isDefaultBackground ? .black.opacity(0.1) : .black.opacity(0.3), radius: 6, y: 3)
+            .shadow(color: ColorTheme.default.textPrimary.opacity(isDefaultBackground ? 0.1 : 0.3), radius: 6, y: 3)
             .padding()
         }
         .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }
@@ -67,6 +67,6 @@ struct WidgetPreview: View {
         if backgroundStyle == "color", let hex = bgColorHex?.uppercased(), hex != "#FFFFFF", let c = Color(hex: hex) {
             return AnyShapeStyle(LinearGradient(colors: [c, c.opacity(0.8)], startPoint: .topLeading, endPoint: .bottomTrailing))
         }
-        return AnyShapeStyle(Color.white)
+        return AnyShapeStyle(ColorTheme.default.backgroundGradient)
     }
 }

--- a/CouplesCountWidget/preview-countdowns.json
+++ b/CouplesCountWidget/preview-countdowns.json
@@ -5,7 +5,7 @@
     "targetUTC": "2025-01-01T00:00:00Z",
     "timeZoneID": "UTC",
     "includeTime": false,
-    "colorTheme": "#0A84FF",
+    "colorTheme": "#D94A6A",
     "hasImage": false,
     "thumbnailBase64": null,
     "lastEdited": "2024-01-01T00:00:00Z"

--- a/Shared/Theme/ColorTheme.swift
+++ b/Shared/Theme/ColorTheme.swift
@@ -1,41 +1,40 @@
 import SwiftUI
 
+/// Semantic color tokens for the app. The app only supports a single light
+/// theme, but the structure remains to keep the `ThemeManager` API stable.
 enum ColorTheme: String, CaseIterable, Codable, Sendable {
-    case light, dark, royalBlues, barbie, lucky
+    case light
 
     static let `default`: ColorTheme = .light
 
-    init(rawOrDefault raw: String?) {
-        self = ColorTheme(rawValue: raw ?? "") ?? .light
+    init(rawOrDefault raw: String?) { self = .light }
+
+    var displayName: String { "Light" }
+
+    /// Primary brand color (Rose)
+    var primary: Color { Color(hex: "#D94A6A") ?? .pink }
+
+    /// Soft accent color (Lavender)
+    var accent: Color { Color(hex: "#C7B8EA") ?? .purple }
+
+    /// Solid fallback background color
+    var background: Color { Color(hex: "#F9FBFF") ?? .white }
+
+    /// Gradient background from baby blue to white
+    var backgroundGradient: LinearGradient {
+        LinearGradient(
+            colors: [Color(hex: "#E7F3FF") ?? .blue.opacity(0.1), .white],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 
-    var displayName: String {
-        switch self {
-        case .light: "Light"
-        case .dark: "Dark"
-        case .royalBlues: "Royal Blues"
-        case .barbie: "Barbie"
-        case .lucky: "Lucky"
-        }
-    }
+    /// Base neutral used for text and outlines (#222222)
+    private var neutralBase: Color { Color(hex: "#222222") ?? .black }
 
-    var background: Color {
-        switch self {
-        case .light: Color(red: 0.867, green: 0.933, blue: 0.996)
-        case .dark: Color(.secondarySystemBackground)
-        case .royalBlues: Color(red: 0.08, green: 0.19, blue: 0.45)
-        case .barbie: Color(red: 0.98, green: 0.36, blue: 0.72)
-        case .lucky: Color(red: 0.10, green: 0.55, blue: 0.28)
-        }
-    }
-
-    var accent: Color {
-        switch self {
-        case .light: .pink
-        case .dark: .white
-        case .royalBlues: .white
-        case .barbie: .white
-        case .lucky: .white
-        }
-    }
+    var textPrimary: Color { neutralBase }
+    var textSecondary: Color { neutralBase.opacity(0.7) }
+    var textTertiary: Color { neutralBase.opacity(0.4) }
+    var outline: Color { neutralBase.opacity(0.15) }
+    var divider: Color { neutralBase.opacity(0.1) }
 }


### PR DESCRIPTION
## Summary
- Define brand color tokens and neutrals in `ColorTheme`
- Update countdown cards, backgrounds, and controls to use semantic colors
- Remove ad-hoc hues and unify UI under a rose/lavender/light gradient palette

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8e595b5c8333884cf74060c4b66c