### PR TITLE
Limit light theme to three colors

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
                     Label("Profile", systemImage: "person.crop.circle")
                 }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
         .onOpenURL { url in
             do {
                 try CountdownShareService.importCountdown(from: url, context: modelContext)
@@ -171,7 +171,7 @@ struct CountdownListView: View {
                                                 .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
 
                                                 .frame(width: 44, height: 44)
-                                                .background(Circle().fill(Color.red))
+                                                .background(Circle().fill(theme.theme.primary))
                                                 .foregroundStyle(.white)
                                                 .accessibilityLabel("Delete")
                                                 .accessibilityHint("Remove countdown")
@@ -193,7 +193,7 @@ struct CountdownListView: View {
                                                 .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
 
                                                 .frame(width: 44, height: 44)
-                                                .background(Circle().fill(Color.blue))
+                                                .background(Circle().fill(theme.theme.accent))
                                                 .foregroundStyle(.white)
                                                 .accessibilityLabel(item.isArchived ? "Unarchive" : "Archive")
                                                 .accessibilityHint(item.isArchived ? "Restore countdown" : "Archive countdown")
@@ -278,6 +278,6 @@ struct CountdownListView: View {
                 PaywallView().environmentObject(theme)
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
     }
 }

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -49,7 +49,7 @@ struct AddEditCountdownView: View {
 
     // Background selection
     @State private var backgroundStyle: String = "color" // "color" | "image"
-    @State private var colorHex: String = "#FFFFFF"
+    @State private var colorHex: String = "#F9FBFF"
     @State private var imageData: Data? = nil
     @State private var showPhotoPicker = false
     @State private var showCamera = false
@@ -57,7 +57,7 @@ struct AddEditCountdownView: View {
     // Live preview values
     @State private var previewTitle: String = "Countdown"
     @State private var previewDate: Date = Date().addingTimeInterval(86_400)
-    @State private var previewColorHex: String = "#FFFFFF"
+    @State private var previewColorHex: String = "#F9FBFF"
     @State private var previewImageData: Data? = nil
 
     // Reminders
@@ -168,21 +168,16 @@ struct AddEditCountdownView: View {
 
                         if backgroundStyle == "color" {
                             HStack(spacing: 10) {
-                                ForEach(["#0A84FF","#5856D6","#FF2D55","#34C759","#FF9F0A"], id: \.self) { hex in
+                                ForEach(["#D94A6A", "#C7B8EA"], id: \.self) { hex in
                                     Circle()
-                                        .fill(Color(hex: hex) ?? .blue)
+                                        .fill(Color(hex: hex)!)
                                         .frame(width: 32, height: 32)
                                         .overlay(
-                                            Circle().stroke(Color.white.opacity(colorHex == hex ? 0.9 : 0), lineWidth: 2)
+                                            Circle().stroke(Color(hex: "#F9FBFF")!.opacity(colorHex == hex ? 0.9 : 0), lineWidth: 2)
                                         )
                                         .onTapGesture { colorHex = hex }
                                 }
                                 Spacer()
-                                ColorPicker("", selection: Binding(
-                                    get: { Color(hex: colorHex) ?? .blue },
-                                    set: { colorHex = $0.hexString }
-                                ))
-                                .labelsHidden()
                             }
                         } else {
                             if let data = imageData, let ui = UIImage(data: data) {
@@ -254,7 +249,7 @@ struct AddEditCountdownView: View {
                                     }
                                     .padding(.horizontal, 8)
                                     .padding(.vertical, 4)
-                                    .background(Color(.systemGray5))
+                                    .background(theme.theme.accent)
                                     .clipShape(Capsule())
                                 }
                             }
@@ -263,11 +258,12 @@ struct AddEditCountdownView: View {
                     }
                     .sheet(isPresented: $showReminderSheet) {
                         ReminderPicker(selections: $selectedReminders)
+                            .environmentObject(theme)
                     }
 
                     if showValidation && title.trimmingCharacters(in: .whitespaces).isEmpty {
                         Text("Please enter a title.")
-                            .foregroundStyle(.red)
+                            .foregroundStyle(theme.theme.primary)
                             .padding(.horizontal, 16)
                     }
 
@@ -314,13 +310,13 @@ struct AddEditCountdownView: View {
             .scrollIndicators(.hidden)
             .overlay(alignment: .trailing) {
                 RoundedRectangle(cornerRadius: 3)
-                    .fill(.gray.opacity(0.4))
+                    .fill(theme.theme.accent.opacity(0.4))
                     .frame(width: 6)
                     .padding(.vertical, 8)
                     .padding(.trailing, 2)
             }
             .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.accent)
+            .tint(theme.theme.primary)
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -399,7 +395,7 @@ struct AddEditCountdownView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
         .alert("Couldn’t Save",
                isPresented: Binding(get: { saveError != nil },
                                    set: { if !$0 { saveError = nil } })) {
@@ -476,6 +472,7 @@ struct AddEditCountdownView: View {
 
 struct ReminderPicker: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var theme: ThemeManager
     @Binding var selections: Set<ReminderOption>
     @State private var temp: Set<ReminderOption>
 
@@ -492,11 +489,11 @@ struct ReminderPicker: View {
                         let isSel = temp.contains(option)
                         Text(option.label)
                             .frame(maxWidth: .infinity, minHeight: 44)
-                            .background(isSel ? Color.accentColor.opacity(0.2) : Color(.systemGray5))
+                            .background(isSel ? theme.theme.primary.opacity(0.2) : theme.theme.background)
                             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 8)
-                                    .stroke(isSel ? Color.accentColor : .clear, lineWidth: 2)
+                                    .stroke(isSel ? theme.theme.primary : .clear, lineWidth: 2)
                             )
                             .onTapGesture {
                                 if isSel { temp.remove(option) } else { temp.insert(option) }

--- a/CouplesCount/Views/Components/AdBannerPlaceholderView.swift
+++ b/CouplesCount/Views/Components/AdBannerPlaceholderView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 
 struct AdBannerPlaceholderView: View {
+    @EnvironmentObject private var theme: ThemeManager
+
     var body: some View {
         Rectangle()
-            .fill(Color.gray.opacity(0.2))
+            .fill(theme.theme.accent.opacity(0.2))
             .frame(height: 50)
             .overlay(
                 Text("Ad Banner")

--- a/CouplesCount/Views/Components/TreeGrowthView.swift
+++ b/CouplesCount/Views/Components/TreeGrowthView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct TreeGrowthView: View {
+    @EnvironmentObject private var theme: ThemeManager
     var progress: Double
     @State private var animated: Double = 0
 
@@ -8,11 +9,11 @@ struct TreeGrowthView: View {
         GeometryReader { geo in
             ZStack(alignment: .bottom) {
                 Rectangle()
-                    .fill(Color.brown)
+                    .fill(theme.theme.primary)
                     .frame(width: geo.size.width * 0.1,
                            height: geo.size.height * CGFloat(animated))
                 Circle()
-                    .fill(Color.green)
+                    .fill(theme.theme.accent)
                     .frame(width: geo.size.width * 0.6,
                            height: geo.size.width * 0.6)
                     .scaleEffect(animated)
@@ -37,4 +38,5 @@ struct TreeGrowthView: View {
 #Preview {
     TreeGrowthView(progress: 0.5)
         .frame(width: 100, height: 100)
+        .environmentObject(ThemeManager())
 }

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -53,7 +53,7 @@ struct CountdownCardView: View {
     private var isDefaultBackground: Bool {
         if backgroundStyle == "image" { return false }
         let hex = colorHex?.uppercased() ?? ""
-        return hex == "" || hex == "#FFFFFF"
+        return hex == "" || hex == "#F9FBFF"
     }
 
     private var primaryText: Color { isDefaultBackground ? .black : .white }
@@ -140,14 +140,10 @@ struct CountdownCardView: View {
     private var backgroundFill: some ShapeStyle {
         if backgroundStyle == "color",
            let hex = colorHex?.uppercased(),
-           hex != "#FFFFFF",
+           hex != "#F9FBFF",
            let c = Color(hex: hex) {
-            return AnyShapeStyle(
-                LinearGradient(colors: [c, c.opacity(0.75)],
-                               startPoint: .topLeading,
-                               endPoint: .bottomTrailing)
-            )
+            return AnyShapeStyle(c)
         }
-        return AnyShapeStyle(Color.white)
+        return AnyShapeStyle(Color(hex: "#F9FBFF")!)
     }
 }

--- a/CouplesCount/Views/CountdownDetailView.swift
+++ b/CouplesCount/Views/CountdownDetailView.swift
@@ -169,7 +169,7 @@ struct CountdownDetailView: View {
             }
         }
         .padding()
-        .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.background))
     }
 
     private func poke(_ p: Participant) {

--- a/CouplesCount/Views/FeedbackFormView.swift
+++ b/CouplesCount/Views/FeedbackFormView.swift
@@ -18,14 +18,14 @@ struct FeedbackFormView: View {
                     .frame(height: 120)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(.secondary.opacity(0.2))
+                            .stroke(theme.theme.accent.opacity(0.2))
                     )
 
                 HStack {
                     ForEach(1...5, id: \.self) { index in
                         Image(systemName: index <= rating ? "star.fill" : "star")
                             .font(.title)
-                            .foregroundStyle(.yellow)
+                            .foregroundStyle(theme.theme.accent)
                             .onTapGesture { rating = index }
                     }
                 }
@@ -49,7 +49,7 @@ struct FeedbackFormView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
     }
 }
 

--- a/CouplesCount/Views/OnboardingView.swift
+++ b/CouplesCount/Views/OnboardingView.swift
@@ -14,7 +14,7 @@ struct OnboardingView: View {
         }
         .tabViewStyle(.page)
         .background(theme.theme.background.ignoresSafeArea())
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
     }
 
     @ViewBuilder
@@ -25,7 +25,7 @@ struct OnboardingView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 120, height: 120)
-                .foregroundStyle(theme.theme.accent)
+                .foregroundStyle(theme.theme.primary)
                 .accessibilityHidden(true)
             Text(text)
                 .font(.title2)
@@ -44,7 +44,7 @@ struct OnboardingView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 120, height: 120)
-                .foregroundStyle(theme.theme.accent)
+                .foregroundStyle(theme.theme.primary)
                 .accessibilityHidden(true)
             Text("Share with your partner.")
                 .font(.title2)
@@ -57,7 +57,7 @@ struct OnboardingView: View {
                     .foregroundStyle(.white)
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.accent))
+                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.primary))
             }
             .padding(.top, 32)
             .padding(.horizontal)

--- a/CouplesCount/Views/PaywallView.swift
+++ b/CouplesCount/Views/PaywallView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 
 struct PaywallView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var theme: ThemeManager
 
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "crown.fill")
                 .font(.largeTitle)
-                .foregroundStyle(.yellow)
+                .foregroundStyle(theme.theme.primary)
                 .accessibilityHidden(true)
             Text("CouplesCount Pro")
                 .font(.title2.weight(.semibold))

--- a/CouplesCount/Views/PremiumPromoView.swift
+++ b/CouplesCount/Views/PremiumPromoView.swift
@@ -14,7 +14,7 @@ struct PremiumPromoView: View {
                 Image(systemName: "crown.fill")
                     .font(.system(size: UIFontMetrics(forTextStyle: .largeTitle).scaledValue(for: 80)))
 
-                    .foregroundStyle(theme.theme.accent)
+                    .foregroundStyle(theme.theme.primary)
                     .accessibilityHidden(true)
                 Text("CouplesCount Premium")
                     .font(.largeTitle.bold())

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -32,12 +32,12 @@ struct ProfileView: View {
                                 Image(systemName: "person.crop.circle.fill")
                                     .resizable()
                                     .scaledToFit()
-                                    .foregroundColor(.gray)
+                                    .foregroundStyle(theme.theme.accent)
                                     .padding(4)
                             }
                         }
                         .frame(width: 80, height: 80)
-                        .background(Color.gray.opacity(profileImageData == nil ? 0.2 : 0))
+                        .background(theme.theme.accent.opacity(profileImageData == nil ? 0.2 : 0))
                         .clipShape(Circle())
                     }
                     .accessibilityLabel("Profile photo")
@@ -125,7 +125,7 @@ struct ProfileView: View {
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
-                            .tint(.red)
+                            .tint(theme.theme.primary)
 
                             Button {
                                 withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {

--- a/CouplesCount/Views/SettingsComponents.swift
+++ b/CouplesCount/Views/SettingsComponents.swift
@@ -14,10 +14,10 @@ struct SettingsCard<Content: View>: View {
             .padding(16)
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(.ultraThinMaterial)
+                    .fill(theme.theme.background)
                     .overlay(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(.white.opacity(0.08), lineWidth: 1)
+                            .stroke(theme.theme.background.opacity(0.08), lineWidth: 1)
                     )
             )
             .shadow(color: .black.opacity(0.12), radius: 12, y: 6)
@@ -55,7 +55,7 @@ struct ThemeSwatch: View {
                     .fill(theme.background)
                     .overlay(
                         RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .stroke(isSelected ? theme.accent : .white.opacity(0.08), lineWidth: isSelected ? 2 : 1)
+                            .stroke(isSelected ? theme.accent : theme.background.opacity(0.08), lineWidth: isSelected ? 2 : 1)
                     )
                     .frame(height: 88)
 
@@ -63,7 +63,7 @@ struct ThemeSwatch: View {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.title2)
                         .symbolRenderingMode(.palette)
-                        .foregroundStyle(.white, theme.accent)
+                        .foregroundStyle(theme.background, theme.accent)
                         .padding(8)
                         .shadow(radius: 4, y: 2)
                         .accessibilityHidden(true)
@@ -76,18 +76,18 @@ struct ThemeSwatch: View {
                         Text("Pro")
                             .font(.caption2.weight(.semibold))
                     }
-                    .foregroundStyle(.yellow)
+                    .foregroundStyle(theme.primary)
                     .padding(6)
-                    .background(.ultraThinMaterial)
+                    .background(theme.background)
                     .clipShape(Capsule())
                     .padding(6)
                 }
 
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 8) {
+                        Circle().fill(theme.primary).frame(width: 10, height: 10)
                         Circle().fill(theme.accent).frame(width: 10, height: 10)
-                        Circle().fill(.white.opacity(0.85)).frame(width: 10, height: 10)
-                        Circle().fill(.black.opacity(0.6)).frame(width: 10, height: 10)
+                        Circle().fill(theme.background).frame(width: 10, height: 10)
                     }
                     .padding(.top, 12)
 

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -119,7 +119,7 @@ struct SettingsView: View {
                 .padding(.top, 8)
             }
             .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.accent)            // accent flows everywhere
+            .tint(theme.theme.primary)            // accent flows everywhere
             .scrollIndicators(.hidden)
             .navigationTitle("Settings")
             .toolbar {
@@ -251,7 +251,7 @@ struct ArchiveView: View {
                                         .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
 
                                         .frame(width: 44, height: 44)
-                                        .background(Circle().fill(Color.red))
+                                        .background(Circle().fill(theme.theme.primary))
                                         .foregroundStyle(.white)
                                         .accessibilityLabel("Delete")
                                         .accessibilityHint("Remove countdown")
@@ -272,7 +272,7 @@ struct ArchiveView: View {
                                         .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
 
                                         .frame(width: 44, height: 44)
-                                        .background(Circle().fill(Color.blue))
+                                        .background(Circle().fill(theme.theme.accent))
                                         .foregroundStyle(.white)
                                         .accessibilityLabel("Unarchive")
                                         .accessibilityHint("Restore countdown")
@@ -295,7 +295,7 @@ struct ArchiveView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.primary)
     }
 }
 

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -14,7 +14,7 @@ struct WidgetPreview: View {
     private var isDefaultBackground: Bool {
         if backgroundStyle == "image" { return false }
         let hex = bgColorHex?.uppercased() ?? ""
-        return hex == "" || hex == "#FFFFFF"
+        return hex == "" || hex == "#F9FBFF"
     }
 
     private var primaryText: Color { isDefaultBackground ? .black : .white }
@@ -64,9 +64,9 @@ struct WidgetPreview: View {
     }
 
     private var backgroundFill: some ShapeStyle {
-        if backgroundStyle == "color", let hex = bgColorHex?.uppercased(), hex != "#FFFFFF", let c = Color(hex: hex) {
-            return AnyShapeStyle(LinearGradient(colors: [c, c.opacity(0.8)], startPoint: .topLeading, endPoint: .bottomTrailing))
+        if backgroundStyle == "color", let hex = bgColorHex?.uppercased(), hex != "#F9FBFF", let c = Color(hex: hex) {
+            return AnyShapeStyle(c)
         }
-        return AnyShapeStyle(Color.white)
+        return AnyShapeStyle(Color(hex: "#F9FBFF")!)
     }
 }

--- a/CouplesCountWidget/preview-countdowns.json
+++ b/CouplesCountWidget/preview-countdowns.json
@@ -5,7 +5,7 @@
     "targetUTC": "2025-01-01T00:00:00Z",
     "timeZoneID": "UTC",
     "includeTime": false,
-    "colorTheme": "#0A84FF",
+    "colorTheme": "#D94A6A",
     "hasImage": false,
     "thumbnailBase64": null,
     "lastEdited": "2024-01-01T00:00:00Z"

--- a/Shared/Models/Countdown.swift
+++ b/Shared/Models/Countdown.swift
@@ -56,7 +56,7 @@ final class Countdown {
          isArchived: Bool = false,
          cardFontStyle: CardFontStyle = .classic,
          backgroundStyle: String = "color",
-         backgroundColorHex: String? = "#FFFFFF",
+         backgroundColorHex: String? = "#F9FBFF",
          backgroundImageData: Data? = nil,
          reminderOffsets: [Int] = [],
          isShared: Bool = false,
@@ -66,7 +66,7 @@ final class Countdown {
         self.targetUTC = targetDate
         self.timeZoneID = timeZoneID
         self.includeTime = true
-        self.colorTheme = backgroundColorHex ?? "#FFFFFF"
+        self.colorTheme = backgroundColorHex ?? "#F9FBFF"
         self.hasImage = backgroundStyle == "image"
         self.imageData = backgroundImageData
         self.cardFontStyleRaw = cardFontStyle.rawValue

--- a/Shared/Theme/ColorTheme.swift
+++ b/Shared/Theme/ColorTheme.swift
@@ -21,7 +21,7 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
 
     var background: Color {
         switch self {
-        case .light: Color(red: 0.867, green: 0.933, blue: 0.996)
+        case .light: Color(hex: "#F9FBFF")!
         case .dark: Color(.secondarySystemBackground)
         case .royalBlues: Color(red: 0.08, green: 0.19, blue: 0.45)
         case .barbie: Color(red: 0.98, green: 0.36, blue: 0.72)
@@ -29,9 +29,19 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
         }
     }
 
+    var primary: Color {
+        switch self {
+        case .light: Color(hex: "#D94A6A")!
+        case .dark: .white
+        case .royalBlues: .white
+        case .barbie: .white
+        case .lucky: .white
+        }
+    }
+
     var accent: Color {
         switch self {
-        case .light: .pink
+        case .light: Color(hex: "#C7B8EA")!
         case .dark: .white
         case .royalBlues: .white
         case .barbie: .white


### PR DESCRIPTION
## Summary
- Simplify light theme palette to three hex tokens and add a dedicated primary color
- Remove gradients and materials, using solid fills for all light surfaces
- Replace remaining UI accents with the new primary/accent colors

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9cff64f0833393caaabf54ebb6c5