### PR TITLE
Refine light theme palette

### DIFF
--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -149,6 +149,9 @@ struct CountdownCardView: View {
     private var backgroundFill: some ShapeStyle {
         if backgroundStyle == "color" {
             let c = cardColor
+            if theme.theme == .light {
+                return AnyShapeStyle(c)
+            }
             return AnyShapeStyle(
                 LinearGradient(colors: [c, c.opacity(0.75)],
                                startPoint: .topLeading,

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -73,6 +73,9 @@ struct WidgetPreview: View {
     private var backgroundFill: some ShapeStyle {
         if backgroundStyle == "color" {
             let c = cardColor
+            if theme.theme == .light {
+                return AnyShapeStyle(c)
+            }
             return AnyShapeStyle(LinearGradient(colors: [c, c.opacity(0.8)], startPoint: .topLeading, endPoint: .bottomTrailing))
         }
         return AnyShapeStyle(theme.theme.primary)

--- a/CouplesCountWidget/CouplesCountWidget.swift
+++ b/CouplesCountWidget/CouplesCountWidget.swift
@@ -79,7 +79,9 @@ struct CouplesCountWidgetView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .containerBackground(
-            LinearGradient(colors: [cardColor, cardColor.opacity(0.75)], startPoint: .topLeading, endPoint: .bottomTrailing),
+            theme == .light ?
+                AnyShapeStyle(cardColor) :
+                AnyShapeStyle(LinearGradient(colors: [cardColor, cardColor.opacity(0.75)], startPoint: .topLeading, endPoint: .bottomTrailing)),
             for: .widget
         )
     }

--- a/Shared/Theme/ColorTheme.swift
+++ b/Shared/Theme/ColorTheme.swift
@@ -21,14 +21,14 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
 
     var primary: Color {
         switch self {
-        case .light: .white
+        case .light: Color(red: 0.851, green: 0.290, blue: 0.416)
         case .dark, .royalBlues, .barbie, .lucky: background
         }
     }
 
     var background: Color {
         switch self {
-        case .light: Color(red: 0.867, green: 0.933, blue: 0.996)
+        case .light: Color(red: 0.976, green: 0.984, blue: 1.000)
         case .dark: Color(.secondarySystemBackground)
         case .royalBlues: Color(red: 0.08, green: 0.19, blue: 0.45)
         case .barbie: Color(red: 0.98, green: 0.36, blue: 0.72)
@@ -38,7 +38,7 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
 
     var accent: Color {
         switch self {
-        case .light: .pink
+        case .light: Color(red: 0.780, green: 0.722, blue: 0.918)
         case .dark: .white
         case .royalBlues: .white
         case .barbie: .white


### PR DESCRIPTION
## Summary
- refresh light theme colors to primary #D94A6A, accent #C7B8EA, and background #F9FBFF
- use solid fills for light cards and widget surfaces

## Testing
- ⚠️ `swift build` *(no Package.swift found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8952361c8333b9aaeed83e71f883