### PR TITLE
Boost contrast in light theme and darken default icon tint

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
                     Label("Profile", systemImage: "person.crop.circle")
                 }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.textPrimary)
         .onOpenURL { url in
             do {
                 try CountdownShareService.importCountdown(from: url, context: modelContext)
@@ -232,8 +232,8 @@ struct CountdownListView: View {
                         Image(systemName: "plus")
                             .font(.title)
                             .padding(20)
-                            .background(Circle().fill(.tint))
-                            .foregroundStyle(.white)
+                            .background(Circle().fill(theme.theme.primary))
+                            .foregroundStyle(Color.white)
                             .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
                             .frame(minWidth: 44, minHeight: 44)
                             .contentShape(Rectangle())
@@ -278,6 +278,6 @@ struct CountdownListView: View {
                 PaywallView().environmentObject(theme)
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.textPrimary)
     }
 }

--- a/CouplesCount/Views/AddEditCountdownView.swift
+++ b/CouplesCount/Views/AddEditCountdownView.swift
@@ -320,7 +320,7 @@ struct AddEditCountdownView: View {
                     .padding(.trailing, 2)
             }
             .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.accent)
+            .tint(theme.theme.textPrimary)
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -406,7 +406,7 @@ struct AddEditCountdownView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.textPrimary)
         .alert("Couldn’t Save",
                isPresented: Binding(get: { saveError != nil },
                                    set: { if !$0 { saveError = nil } })) {

--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -54,19 +54,12 @@ struct CountdownCardView: View {
         resolvedCardColor(theme: theme.theme, backgroundStyle: backgroundStyle, colorHex: colorHex)
     }
 
-    private var primaryText: Color {
-        if backgroundStyle == "image" { return .white }
-        return cardColor.readablePrimary
-    }
+    private var primaryText: Color { cardColor.readablePrimary }
 
-    private var secondaryText: Color {
-        if backgroundStyle == "image" { return Color.white.opacity(0.9) }
-        return cardColor.readableSecondary
-    }
+    private var secondaryText: Color { cardColor.readableSecondary }
 
     private var shareButtonBg: Color {
-        if backgroundStyle == "image" { return Color.white.opacity(0.25) }
-        return primaryText.opacity(cardColor.isLight ? 0.05 : 0.25)
+        primaryText.opacity(cardColor.isLight ? 0.05 : 0.25)
     }
 
     var body: some View {
@@ -90,8 +83,7 @@ struct CountdownCardView: View {
                 .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: corner, style: .continuous)
-                        .stroke(Color.black.opacity(0.25), lineWidth: 4)
-
+                        .stroke(Color.black, lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.15), radius: 10, y: 6)
 

--- a/CouplesCount/Views/FeedbackFormView.swift
+++ b/CouplesCount/Views/FeedbackFormView.swift
@@ -39,6 +39,7 @@ struct FeedbackFormView: View {
                 .frame(maxWidth: .infinity)
                 .controlSize(.large)
                 .buttonStyle(.borderedProminent)
+                .tint(theme.theme.primary)
             }
             .padding()
             .navigationTitle("Feedback")
@@ -49,7 +50,7 @@ struct FeedbackFormView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.textPrimary)
     }
 }
 

--- a/CouplesCount/Views/OnboardingView.swift
+++ b/CouplesCount/Views/OnboardingView.swift
@@ -14,7 +14,7 @@ struct OnboardingView: View {
         }
         .tabViewStyle(.page)
         .background(theme.theme.background.ignoresSafeArea())
-        .tint(theme.theme.accent)
+        .tint(theme.theme.textPrimary)
     }
 
     @ViewBuilder
@@ -25,11 +25,12 @@ struct OnboardingView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 120, height: 120)
-                .foregroundStyle(theme.theme.accent)
+                .foregroundStyle(theme.theme.textPrimary)
                 .accessibilityHidden(true)
             Text(text)
                 .font(.title2)
                 .multilineTextAlignment(.center)
+                .foregroundStyle(theme.theme.textPrimary)
                 .padding(.top, 24)
                 .padding(.horizontal)
             Spacer()
@@ -44,20 +45,21 @@ struct OnboardingView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 120, height: 120)
-                .foregroundStyle(theme.theme.accent)
+                .foregroundStyle(theme.theme.primary)
                 .accessibilityHidden(true)
             Text("Share with your partner.")
                 .font(.title2)
                 .multilineTextAlignment(.center)
+                .foregroundStyle(theme.theme.textPrimary)
                 .padding(.top, 24)
                 .padding(.horizontal)
             Button(action: finishOnboarding) {
                 Text("Done")
                     .font(.headline)
-                    .foregroundStyle(theme.theme.accent.readablePrimary)
+                    .foregroundStyle(Color.white)
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.accent))
+                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.primary))
             }
             .padding(.top, 32)
             .padding(.horizontal)

--- a/CouplesCount/Views/PremiumPromoView.swift
+++ b/CouplesCount/Views/PremiumPromoView.swift
@@ -13,8 +13,7 @@ struct PremiumPromoView: View {
                 Spacer()
                 Image(systemName: "crown.fill")
                     .font(.system(size: UIFontMetrics(forTextStyle: .largeTitle).scaledValue(for: 80)))
-
-                    .foregroundStyle(theme.theme.accent)
+                    .foregroundStyle(theme.theme.primary)
                     .accessibilityHidden(true)
                 Text("CouplesCount Premium")
                     .font(.largeTitle.bold())
@@ -26,6 +25,7 @@ struct PremiumPromoView: View {
                 Spacer()
             }
         }
+        .tint(theme.theme.textPrimary)
         .safeAreaInset(edge: .top, alignment: .leading) {
             Button {
                 withAnimation(.spring()) { show = false }

--- a/CouplesCount/Views/SettingsComponents.swift
+++ b/CouplesCount/Views/SettingsComponents.swift
@@ -27,12 +27,13 @@ struct SettingsCard<Content: View>: View {
 
 // Section label that floats above the card
 struct SectionHeader: View {
+    @EnvironmentObject private var theme: ThemeManager
     let text: String
     var body: some View {
         HStack {
             Text(text.uppercased())
                 .font(.footnote.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(theme.theme.textSecondary)
             Spacer()
         }
         .padding(.horizontal, 16)

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -70,7 +70,7 @@ struct SettingsView: View {
                               HStack(spacing: 12) {
                                   Image(systemName: "archivebox.fill")
                                       .font(.title3)
-                                      .foregroundStyle(theme.theme.background)
+                                      .foregroundStyle(theme.theme.textPrimary)
                                       .frame(width: 30, height: 30)
                                       .background(
                                           RoundedRectangle(cornerRadius: 8)
@@ -79,6 +79,7 @@ struct SettingsView: View {
                                       .accessibilityHidden(true)
                                   Text("Manage Archive")
                                       .font(.body)
+                                      .foregroundStyle(theme.theme.textPrimary)
                                   Spacer()
                               }
                             .contentShape(Rectangle())
@@ -119,7 +120,7 @@ struct SettingsView: View {
                 .padding(.top, 8)
             }
             .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.accent)            // accent flows everywhere
+            .tint(theme.theme.textPrimary)            // default icons
             .scrollIndicators(.hidden)
             .navigationTitle("Settings")
             .toolbar {
@@ -170,14 +171,16 @@ struct SettingsView: View {
             HStack(spacing: 12) {
                 Image(systemName: icon)
                     .font(.title3)
-                    .foregroundStyle(theme.theme.background)
+                    .foregroundStyle(theme.theme.textPrimary)
                     .frame(width: 30, height: 30)
                     .background(
                         RoundedRectangle(cornerRadius: 8)
                             .fill(theme.theme.accent)
                     )
                     .accessibilityHidden(true)
-                Text(title).font(.body)
+                Text(title)
+                    .font(.body)
+                    .foregroundStyle(theme.theme.textPrimary)
                 Spacer()
             }
             .contentShape(Rectangle())
@@ -295,7 +298,7 @@ struct ArchiveView: View {
                 }
             }
         }
-        .tint(theme.theme.accent)
+        .tint(theme.theme.textPrimary)
     }
 }
 

--- a/CouplesCount/Views/WidgetPreview.swift
+++ b/CouplesCount/Views/WidgetPreview.swift
@@ -17,15 +17,9 @@ struct WidgetPreview: View {
         resolvedCardColor(theme: theme.theme, backgroundStyle: backgroundStyle, colorHex: bgColorHex)
     }
 
-    private var primaryText: Color {
-        if backgroundStyle == "image" { return .white }
-        return cardColor.readablePrimary
-    }
+    private var primaryText: Color { cardColor.readablePrimary }
 
-    private var secondaryText: Color {
-        if backgroundStyle == "image" { return Color.white.opacity(0.9) }
-        return cardColor.readableSecondary
-    }
+    private var secondaryText: Color { cardColor.readableSecondary }
 
     var body: some View {
         ZStack {
@@ -45,8 +39,7 @@ struct WidgetPreview: View {
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 22, style: .continuous)
-                        .stroke(Color.black.opacity(0.25), lineWidth: 1)
-
+                        .stroke(Color.black, lineWidth: 1)
                 )
                 .frame(height: 140)
 

--- a/Shared/Theme/ColorTheme.swift
+++ b/Shared/Theme/ColorTheme.swift
@@ -45,4 +45,29 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
         case .lucky: .white
         }
     }
+
+    // MARK: - Text colors
+
+    private static let lightTextPrimary = Color(red: 0.067, green: 0.067, blue: 0.067) // #111111
+
+    var textPrimary: Color {
+        switch self {
+        case .light: Self.lightTextPrimary
+        case .dark, .royalBlues, .barbie, .lucky: .white
+        }
+    }
+
+    var textSecondary: Color {
+        switch self {
+        case .light: Self.lightTextPrimary.opacity(0.65)
+        case .dark, .royalBlues, .barbie, .lucky: Color.white.opacity(0.7)
+        }
+    }
+
+    var textTertiary: Color {
+        switch self {
+        case .light: Self.lightTextPrimary.opacity(0.45)
+        case .dark, .royalBlues, .barbie, .lucky: Color.white.opacity(0.45)
+        }
+    }
 }

--- a/Shared/Utilities/Color+Contrast.swift
+++ b/Shared/Utilities/Color+Contrast.swift
@@ -22,11 +22,12 @@ extension Color {
 ///   - theme: Active `ColorTheme` providing the default color.
 ///   - backgroundStyle: `"color"` or `"image"`.
 ///   - colorHex: Optional hex override saved with the countdown.
-/// - Returns: Chosen color following precedence: override > theme default > white.
+/// - Returns: Chosen color following precedence: override > theme default > fallback.
 func resolvedCardColor(theme: ColorTheme, backgroundStyle: String, colorHex: String?) -> Color {
     guard backgroundStyle == "color" else { return theme.primary }
     let upper = colorHex?.uppercased() ?? ""
-    if upper != "" && upper != "#FFFFFF" && upper != theme.primary.hexString.uppercased(),
+    let defaults = Set(ColorTheme.allCases.map { $0.primary.hexString.uppercased() })
+    if upper != "" && upper != "#FFFFFF" && !defaults.contains(upper),
        let c = Color(hex: upper) {
         return c
     }


### PR DESCRIPTION
## Summary
- Define reusable text color tokens and improve card color resolution
- Darken default icon tint and style primary buttons with bold brand colors
- Outline countdown cards in solid black for higher contrast

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8b83644c8333b84852fe80e909b5