### PR TITLE
Ensure light theme header uses dark text

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -80,6 +80,7 @@ struct CountdownListView: View {
                         Spacer()
                         Text(Date.now, format: .dateTime.weekday(.wide).month().day())
                             .font(.system(size: UIFontMetrics(forTextStyle: .title1).scaledValue(for: 28), weight: .semibold))
+                            .foregroundStyle(theme.theme == .light ? theme.theme.textPrimary : .primary)
 
                         Spacer()
                         Button { showSettings = true } label: {


### PR DESCRIPTION
## Summary
- Use dark text token for date header in light theme only

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90aed0e083338c43b097b7c9a06e