### PR TITLE
Refactor Settings styling to rely on theme tokens

### DIFF
--- a/CouplesCount/Views/SettingsComponents.swift
+++ b/CouplesCount/Views/SettingsComponents.swift
@@ -14,13 +14,13 @@ struct SettingsCard<Content: View>: View {
             .padding(16)
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(.ultraThinMaterial)
+                    .fill(theme.theme.background)
                     .overlay(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(.white.opacity(0.08), lineWidth: 1)
+                            .stroke(Color.black, lineWidth: 1)
                     )
             )
-            .shadow(color: .black.opacity(0.12), radius: 12, y: 6)
+            .shadow(color: theme.theme.textPrimary.opacity(0.12), radius: 12, y: 6)
             .padding(.horizontal, 16)
     }
 }
@@ -43,7 +43,6 @@ struct SectionHeader: View {
 
 // A large, tappable theme swatch
 struct ThemeSwatch: View {
-    @EnvironmentObject private var themeManager: ThemeManager
     let theme: ColorTheme
     let isSelected: Bool
     let isLocked: Bool
@@ -56,7 +55,11 @@ struct ThemeSwatch: View {
                     .fill(theme.background)
                     .overlay(
                         RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .stroke(isSelected ? theme.accent : .white.opacity(0.08), lineWidth: isSelected ? 2 : 1)
+                            .stroke(Color.black, lineWidth: 1)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(isSelected ? theme.primary : .clear, lineWidth: 2)
                     )
                     .frame(height: 88)
 
@@ -64,9 +67,9 @@ struct ThemeSwatch: View {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.title2)
                         .symbolRenderingMode(.palette)
-                        .foregroundStyle(theme.primary, theme.accent)
+                        .foregroundStyle(theme.primary, theme.textPrimary)
                         .padding(8)
-                        .shadow(radius: 4, y: 2)
+                        .shadow(color: theme.textPrimary.opacity(0.4), radius: 4, y: 2)
                         .accessibilityHidden(true)
                 }
 
@@ -77,9 +80,9 @@ struct ThemeSwatch: View {
                         Text("Pro")
                             .font(.caption2.weight(.semibold))
                     }
-                    .foregroundStyle(.yellow)
+                    .foregroundStyle(theme.textPrimary)
                     .padding(6)
-                    .background(.ultraThinMaterial)
+                    .background(theme.accent)
                     .clipShape(Capsule())
                     .padding(6)
                 }
@@ -87,14 +90,14 @@ struct ThemeSwatch: View {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 8) {
                         Circle().fill(theme.accent).frame(width: 10, height: 10)
-                        Circle().fill(.white.opacity(0.85)).frame(width: 10, height: 10)
-                        Circle().fill(.black.opacity(0.6)).frame(width: 10, height: 10)
+                        Circle().fill(theme.textPrimary).frame(width: 10, height: 10)
+                        Circle().fill(theme.textSecondary).frame(width: 10, height: 10)
                     }
                     .padding(.top, 12)
 
                     Text(theme.displayName)
                         .font(.callout.weight(.semibold))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(theme.textPrimary)
                         .lineLimit(1)
                 }
                 .padding(12)

--- a/CouplesCount/Views/SettingsView.swift
+++ b/CouplesCount/Views/SettingsView.swift
@@ -9,7 +9,7 @@ struct SettingsView: View {
     @EnvironmentObject private var theme: ThemeManager
     @EnvironmentObject private var pro: ProStatusProvider
 
-    private let themes: [ColorTheme] = [.light, .dark, .royalBlues, .barbie, .lucky]
+    private let themes: [ColorTheme] = [.light, .dark, .royalBlues, .barbie]
     private let supportEmail = "support@couplescount.app"
     @State private var activeAlert: ActiveAlert?
     @State private var showEnjoyPrompt = false
@@ -38,7 +38,6 @@ struct SettingsView: View {
                                             theme.setTheme(t)   // instant global update
                                         }
                                     }
-                                    .environmentObject(theme)
                                 }
                             }
                         }
@@ -48,7 +47,7 @@ struct SettingsView: View {
                         SettingsCard {
                             buttonRow(icon: "crown.fill", title: "Go Pro") { showPaywall = true }
 #if DEBUG
-                            Divider().opacity(0.1)
+                            Divider().overlay(theme.theme.textPrimary.opacity(0.1))
                             Toggle("Simulate Pro", isOn: $pro.debugIsPro)
 #endif
                         }
@@ -95,7 +94,7 @@ struct SettingsView: View {
                                 openURL(url)
                             }
                         }
-                        Divider().opacity(0.1)
+                        Divider().overlay(theme.theme.textPrimary.opacity(0.1))
                         buttonRow(icon: "star.fill", title: "Rate CouplesCount") {
                             showEnjoyPrompt = true
                         }
@@ -108,7 +107,7 @@ struct SettingsView: View {
                             key: "Version",
                             value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
                         )
-                        Divider().opacity(0.08)
+                        Divider().overlay(theme.theme.textPrimary.opacity(0.08))
                         keyValueRow(
                             key: "Build",
                             value: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
@@ -192,9 +191,10 @@ struct SettingsView: View {
     private func keyValueRow(key: String, value: String) -> some View {
         HStack {
             Text(key)
+                .foregroundStyle(theme.theme.textPrimary)
             Spacer()
             Text(value)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(theme.theme.textSecondary)
         }
         .font(.body)
     }
@@ -217,7 +217,7 @@ struct ArchiveView: View {
                     VStack(spacing: 8) {
                         Text("No archived countdowns")
                             .font(.headline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(theme.theme.textSecondary)
                     }
                 } else {
                     List {
@@ -252,10 +252,9 @@ struct ArchiveView: View {
                                 } label: {
                                     Image(systemName: "trash")
                                         .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
-
                                         .frame(width: 44, height: 44)
-                                        .background(Circle().fill(Color.red))
-                                        .foregroundStyle(.white)
+                                        .background(Circle().fill(theme.theme.primary))
+                                        .foregroundStyle(theme.theme.textPrimary)
                                         .accessibilityLabel("Delete")
                                         .accessibilityHint("Remove countdown")
                                 }
@@ -273,10 +272,9 @@ struct ArchiveView: View {
                                 } label: {
                                     Image(systemName: "arrow.uturn.backward")
                                         .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
-
                                         .frame(width: 44, height: 44)
-                                        .background(Circle().fill(Color.blue))
-                                        .foregroundStyle(.white)
+                                        .background(Circle().fill(theme.theme.primary))
+                                        .foregroundStyle(theme.theme.textPrimary)
                                         .accessibilityLabel("Unarchive")
                                         .accessibilityHint("Restore countdown")
                                 }

--- a/Shared/Theme/ColorTheme.swift
+++ b/Shared/Theme/ColorTheme.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum ColorTheme: String, CaseIterable, Codable, Sendable {
-    case light, dark, royalBlues, barbie, lucky
+    case light, dark, royalBlues, barbie
 
     static let `default`: ColorTheme = .light
 
@@ -15,14 +15,13 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
         case .dark: "Dark"
         case .royalBlues: "Royal Blues"
         case .barbie: "Barbie"
-        case .lucky: "Lucky"
         }
     }
 
     var primary: Color {
         switch self {
         case .light: Color(red: 0.851, green: 0.290, blue: 0.416)
-        case .dark, .royalBlues, .barbie, .lucky: background
+        case .dark, .royalBlues, .barbie: background
         }
     }
 
@@ -32,7 +31,6 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
         case .dark: Color(.secondarySystemBackground)
         case .royalBlues: Color(red: 0.08, green: 0.19, blue: 0.45)
         case .barbie: Color(red: 0.98, green: 0.36, blue: 0.72)
-        case .lucky: Color(red: 0.10, green: 0.55, blue: 0.28)
         }
     }
 
@@ -42,7 +40,6 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
         case .dark: .white
         case .royalBlues: .white
         case .barbie: .white
-        case .lucky: .white
         }
     }
 
@@ -53,21 +50,21 @@ enum ColorTheme: String, CaseIterable, Codable, Sendable {
     var textPrimary: Color {
         switch self {
         case .light: Self.lightTextPrimary
-        case .dark, .royalBlues, .barbie, .lucky: .white
+        case .dark, .royalBlues, .barbie: .white
         }
     }
 
     var textSecondary: Color {
         switch self {
         case .light: Self.lightTextPrimary.opacity(0.65)
-        case .dark, .royalBlues, .barbie, .lucky: Color.white.opacity(0.7)
+        case .dark, .royalBlues, .barbie: Color.white.opacity(0.7)
         }
     }
 
     var textTertiary: Color {
         switch self {
         case .light: Self.lightTextPrimary.opacity(0.45)
-        case .dark, .royalBlues, .barbie, .lucky: Color.white.opacity(0.45)
+        case .dark, .royalBlues, .barbie: Color.white.opacity(0.45)
         }
     }
 }

--- a/Shared/Theme/ThemeManager.swift
+++ b/Shared/Theme/ThemeManager.swift
@@ -11,6 +11,9 @@ final class ThemeManager: ObservableObject {
     init() {
         let raw = defaults.string(forKey: key)
         self.theme = ColorTheme(rawOrDefault: raw)
+        if raw == "lucky" {
+            defaults.set(ColorTheme.light.rawValue, forKey: key)
+        }
     }
 
     // Update theme and notify widgets.


### PR DESCRIPTION
## Summary
- remove obsolete Lucky theme and coerce any stored value to Light
- drive Settings UI entirely by theme tokens with black card borders
- render theme picker swatches with themed previews and live updates

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac961584f88333a2eacfcb959e722e