### PR TITLE
Add blank countdown detail view and modal presentation

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -52,6 +52,7 @@ struct CountdownListView: View {
     @State private var showShareSheet = false
     @State private var pressingID: UUID? = nil
     @State private var showPaywall = false
+    @State private var showingBlankDetail = false
 
     var refreshAction: (() async -> Void)? = nil
 
@@ -133,6 +134,9 @@ struct CountdownListView: View {
                                 card
                                     .environmentObject(theme)
                                     .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        showingBlankDetail = true
+                                    }
                                     .scaleEffect(pressingID == item.id ? 0.97 : 1)
                                     .animation(.spring(response: 0.3, dampingFraction: 0.7), value: pressingID == item.id)
                                   .onLongPressGesture(minimumDuration: 0.4, maximumDistance: 50, pressing: { pressing in
@@ -260,6 +264,10 @@ struct CountdownListView: View {
             }
             .sheet(isPresented: $showPaywall) {
                 PaywallView().environmentObject(theme)
+            }
+            .fullScreenCover(isPresented: $showingBlankDetail) {
+                BlankDetailView()
+                    .environmentObject(theme)
             }
         }
         .tint(theme.theme.textPrimary)

--- a/CouplesCount/Views/BlankDetailView.swift
+++ b/CouplesCount/Views/BlankDetailView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct BlankDetailView: View {
+    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack {
+            theme.theme.background
+                .ignoresSafeArea()
+            Text("Detail (blank)")
+                .font(.title2)
+        }
+        .overlay(alignment: .topLeading) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.title2)
+                    .padding()
+                    .foregroundStyle(theme.theme.textPrimary)
+            }
+        }
+    }
+}
+
+#Preview {
+    BlankDetailView().environmentObject(ThemeManager())
+}


### PR DESCRIPTION
## Summary
- create basic `BlankDetailView` with theme background, centered label, and dismiss button
- show the blank detail view when tapping a countdown card via `fullScreenCover`

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68addd325440833380a71468f17f7603