### PR TITLE
refactor: centralize countdown swipe actions

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownRowActions.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowActions.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import UIKit
+
+@ViewBuilder
+func DeleteSwipeButton(
+    _ action: @escaping () -> Void,
+    label: String = "Delete",
+    hint: String = "Remove countdown",
+    iconOnly: Bool = true,
+    background: Color = .red,
+    foreground: Color = .white
+) -> some View {
+    Button(role: .destructive, action: action) {
+        if iconOnly {
+            Image(systemName: "trash")
+                .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
+                .frame(width: 44, height: 44)
+                .background(Circle().fill(background))
+                .foregroundStyle(foreground)
+                .accessibilityLabel(label)
+                .accessibilityHint(hint)
+        } else {
+            Label(label, systemImage: "trash")
+        }
+    }
+    .tint(iconOnly ? .clear : background)
+    .contentShape(Rectangle())
+}
+
+@ViewBuilder
+func ArchiveSwipeButton(
+    _ action: @escaping () -> Void,
+    label: String = "Archive",
+    systemImage: String = "archivebox",
+    hint: String = "Archive countdown",
+    iconOnly: Bool = true,
+    background: Color = .blue,
+    foreground: Color = .white
+) -> some View {
+    Button(action: action) {
+        if iconOnly {
+            Image(systemName: systemImage)
+                .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
+                .frame(width: 44, height: 44)
+                .background(Circle().fill(background))
+                .foregroundStyle(foreground)
+                .accessibilityLabel(label)
+                .accessibilityHint(hint)
+        } else {
+            Label(label, systemImage: systemImage)
+        }
+    }
+    .tint(iconOnly ? .clear : background)
+    .contentShape(Rectangle())
+}
+
+@ViewBuilder
+func ShareSwipeButton(
+    _ action: @escaping () -> Void,
+    label: String = "Share",
+    hint: String = "Share countdown",
+    iconOnly: Bool = true,
+    background: Color = .blue,
+    foreground: Color = .white
+) -> some View {
+    Button(action: action) {
+        if iconOnly {
+            Image(systemName: "square.and.arrow.up")
+                .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
+                .frame(width: 44, height: 44)
+                .background(Circle().fill(background))
+                .foregroundStyle(foreground)
+                .accessibilityLabel(label)
+                .accessibilityHint(hint)
+        } else {
+            Label(label, systemImage: "square.and.arrow.up")
+        }
+    }
+    .tint(iconOnly ? .clear : background)
+    .contentShape(Rectangle())
+}
+

--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -50,30 +50,15 @@ struct CountdownRowView: View {
         .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
         .listRowBackground(theme.theme.background)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            Button { onDelete(countdown) } label: {
-                Image(systemName: "trash")
-                    .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
-                    .frame(width: 44, height: 44)
-                    .background(Circle().fill(Color.red))
-                    .foregroundStyle(.white)
-                    .accessibilityLabel("Delete")
-                    .accessibilityHint("Remove countdown")
-            }
-            .tint(.clear)
-            .contentShape(Rectangle())
+            DeleteSwipeButton { onDelete(countdown) }
         }
         .swipeActions(edge: .leading, allowsFullSwipe: false) {
-            Button { onArchiveToggle(countdown) } label: {
-                Image(systemName: countdown.isArchived ? "arrow.uturn.backward" : "archivebox")
-                    .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
-                    .frame(width: 44, height: 44)
-                    .background(Circle().fill(Color.blue))
-                    .foregroundStyle(.white)
-                    .accessibilityLabel(countdown.isArchived ? "Unarchive" : "Archive")
-                    .accessibilityHint(countdown.isArchived ? "Restore countdown" : "Archive countdown")
-            }
-            .tint(.clear)
-            .contentShape(Rectangle())
+            ArchiveSwipeButton(
+                { onArchiveToggle(countdown) },
+                label: countdown.isArchived ? "Unarchive" : "Archive",
+                systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox",
+                hint: countdown.isArchived ? "Restore countdown" : "Archive countdown"
+            )
         }
     }
 }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -114,7 +114,7 @@ struct ProfileView: View {
                         )
                         .environmentObject(theme)
                         .contextMenu {
-                            Button(role: .destructive) {
+                            DeleteSwipeButton({
                                 withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                                     modelContext.delete(item)
                                     try? modelContext.save()
@@ -122,12 +122,9 @@ struct ProfileView: View {
                                     updateWidgetSnapshot(afterSaving: all)
                                 }
                                 Haptics.warning()
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                            .tint(.red)
+                            }, iconOnly: false)
 
-                            Button {
+                            ArchiveSwipeButton({
                                 withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                                     item.isArchived = true
                                     try? modelContext.save()
@@ -135,9 +132,7 @@ struct ProfileView: View {
                                     updateWidgetSnapshot(afterSaving: all)
                                 }
                                 Haptics.light()
-                            } label: {
-                                Label("Archive", systemImage: "archivebox")
-                            }
+                            }, iconOnly: false)
                         }
                     }
                 }

--- a/CouplesCount/Views/Settings/ArchiveView.swift
+++ b/CouplesCount/Views/Settings/ArchiveView.swift
@@ -42,45 +42,36 @@ struct ArchiveView: View {
                             .listRowSeparator(.hidden)
                             .listRowInsets(.init(top: 0, leading: 16, bottom: 0, trailing: 16))
                             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                Button {
-                                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
-                                        modelContext.delete(item)
-                                        try? modelContext.save()
-                                        let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                        updateWidgetSnapshot(afterSaving: all)
-                                    }
-                                    Haptics.warning()
-                                } label: {
-                                    Image(systemName: "trash")
-                                        .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
-                                        .frame(width: 44, height: 44)
-                                        .background(Circle().fill(theme.theme.primary))
-                                        .foregroundStyle(theme.theme.textPrimary)
-                                        .accessibilityLabel("Delete")
-                                        .accessibilityHint("Remove countdown")
-                                }
-                                .tint(.clear)
-                                .contentShape(Rectangle())
+                                DeleteSwipeButton(
+                                    {
+                                        withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                            modelContext.delete(item)
+                                            try? modelContext.save()
+                                            let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                            updateWidgetSnapshot(afterSaving: all)
+                                        }
+                                        Haptics.warning()
+                                    },
+                                    background: theme.theme.primary,
+                                    foreground: theme.theme.textPrimary
+                                )
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: false) {
-                                Button {
-                                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
-                                        item.isArchived = false
-                                        try? modelContext.save()
-                                        let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
-                                        updateWidgetSnapshot(afterSaving: all)
-                                    }
-                                } label: {
-                                    Image(systemName: "arrow.uturn.backward")
-                                        .font(.system(size: UIFontMetrics(forTextStyle: .body).scaledValue(for: 16), weight: .bold))
-                                        .frame(width: 44, height: 44)
-                                        .background(Circle().fill(theme.theme.primary))
-                                        .foregroundStyle(theme.theme.textPrimary)
-                                        .accessibilityLabel("Unarchive")
-                                        .accessibilityHint("Restore countdown")
-                                }
-                                .tint(.clear)
-                                .contentShape(Rectangle())
+                                ArchiveSwipeButton(
+                                    {
+                                        withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                            item.isArchived = false
+                                            try? modelContext.save()
+                                            let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
+                                            updateWidgetSnapshot(afterSaving: all)
+                                        }
+                                    },
+                                    label: "Unarchive",
+                                    systemImage: "arrow.uturn.backward",
+                                    hint: "Restore countdown",
+                                    background: theme.theme.primary,
+                                    foreground: theme.theme.textPrimary
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- add reusable swipe action helpers for countdown rows
- refactor row views to use shared Archive, Delete, and Share swipe buttons

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68adef8b9cb88333bd3e9455046e1859