### PR TITLE
Make row navigation explicit

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -19,11 +19,13 @@ struct CountdownListView: View {
     @State private var showPaywall = false
     @State private var showingBlankDetail = false
     @Namespace private var heroNamespace
+    @AppStorage("useHeroTransition") private var useHeroTransition = false
+    @State private var navigationPath = NavigationPath()
 
     var refreshAction: (() async -> Void)? = nil
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             ZStack {
                 theme.theme.background.ignoresSafeArea()
 
@@ -42,7 +44,8 @@ struct CountdownListView: View {
                             showShareSheet: $showShareSheet,
                             showingBlankDetail: $showingBlankDetail,
                             refreshAction: refreshAction,
-                            heroNamespace: heroNamespace
+                            heroNamespace: heroNamespace,
+                            useHeroTransition: useHeroTransition
                         )
                     }
 
@@ -67,8 +70,13 @@ struct CountdownListView: View {
             .sheet(isPresented: $showShareSheet, content: shareSheet)
             .sheet(isPresented: $showPaywall, content: paywallSheet)
             .fullScreenCover(isPresented: $showingBlankDetail) {
-                blankDetailOverlay(isPresented: $showingBlankDetail, onClose: { showingBlankDetail = false })
+                if useHeroTransition {
+                    blankDetailOverlay(isPresented: $showingBlankDetail, onClose: { showingBlankDetail = false })
+                }
             }
+        }
+        .navigationDestination(for: UUID.self) { _ in
+            BlankDetailView().environmentObject(theme)
         }
         .tint(theme.theme.textPrimary)
     }
@@ -220,6 +228,7 @@ private struct CountdownListSection: View {
     @Binding var showingBlankDetail: Bool
     var refreshAction: (() async -> Void)?
     var heroNamespace: Namespace.ID
+    let useHeroTransition: Bool
 
     var body: some View {
         List {
@@ -227,6 +236,7 @@ private struct CountdownListSection: View {
                 CountdownRowView(
                     countdown: item,
                     heroNamespace: heroNamespace,
+                    useHeroTransition: useHeroTransition,
                     onShare: { url in
                         shareURL = url
                         showShareSheet = true
@@ -254,7 +264,9 @@ private struct CountdownListSection: View {
                         if countdown.isArchived { Haptics.light() }
                     },
                     onSelect: { _ in
-                        showingBlankDetail = true
+                        if useHeroTransition {
+                            showingBlankDetail = true
+                        }
                     }
                 )
             }

--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -6,6 +6,7 @@ struct CountdownRowView: View {
 
     let countdown: Countdown
     let heroNamespace: Namespace.ID
+    let useHeroTransition: Bool
     let onShare: (URL) -> Void
     let onEdit: (Countdown) -> Void
     let onDelete: (Countdown) -> Void
@@ -18,7 +19,7 @@ struct CountdownRowView: View {
         let dateText = DateUtils.readableDate.string(from: countdown.targetDate)
         let exportURL = CountdownShareService.exportURL(for: countdown)
 
-        CountdownCardView(
+        let card = CountdownCardView(
             title: countdown.title,
             targetDate: countdown.targetDate,
             timeZoneID: countdown.timeZoneID,
@@ -35,7 +36,6 @@ struct CountdownRowView: View {
         )
         .environmentObject(theme)
         .contentShape(Rectangle())
-        .onTapGesture { onSelect(countdown) }
         .scaleEffect(isPressing ? 0.97 : 1)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isPressing)
         .onLongPressGesture(minimumDuration: 0.4, maximumDistance: 50, pressing: { pressing in
@@ -46,20 +46,36 @@ struct CountdownRowView: View {
             Haptics.light()
             onEdit(countdown)
         }
-        .listRowSeparator(.hidden)
-        .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
-        .listRowBackground(theme.theme.background)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            DeleteSwipeButton { onDelete(countdown) }
-        }
-        .swipeActions(edge: .leading, allowsFullSwipe: false) {
-            ArchiveSwipeButton(
-                { onArchiveToggle(countdown) },
-                label: countdown.isArchived ? "Unarchive" : "Archive",
-                systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox",
-                hint: countdown.isArchived ? "Restore countdown" : "Archive countdown"
+
+        if useHeroTransition {
+            styledRow(
+                card.onTapGesture { onSelect(countdown) }
+            )
+        } else {
+            styledRow(
+                NavigationLink(value: countdown.id) {
+                    card
+                }
             )
         }
     }
-}
 
+    @ViewBuilder
+    private func styledRow<Content: View>(_ content: Content) -> some View {
+        content
+            .listRowSeparator(.hidden)
+            .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
+            .listRowBackground(theme.theme.background)
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                DeleteSwipeButton { onDelete(countdown) }
+            }
+            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                ArchiveSwipeButton(
+                    { onArchiveToggle(countdown) },
+                    label: countdown.isArchived ? "Unarchive" : "Archive",
+                    systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox",
+                    hint: countdown.isArchived ? "Restore countdown" : "Archive countdown"
+                )
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- use NavigationLink for default countdown row navigation
- gate hero overlay transition behind `useHeroTransition`
- prepare NavigationStack path to support deep links

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68adf231c5648333b5f8241cb85faab0