### PR TITLE
Make row navigation explicit

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -6,6 +6,7 @@ struct CountdownRowView: View {
 
     let countdown: Countdown
     let heroNamespace: Namespace.ID
+    let useHeroTransition: Bool
     let onShare: (URL) -> Void
     let onEdit: (Countdown) -> Void
     let onDelete: (Countdown) -> Void
@@ -18,7 +19,7 @@ struct CountdownRowView: View {
         let dateText = DateUtils.readableDate.string(from: countdown.targetDate)
         let exportURL = CountdownShareService.exportURL(for: countdown)
 
-        CountdownCardView(
+        let card = CountdownCardView(
             title: countdown.title,
             targetDate: countdown.targetDate,
             timeZoneID: countdown.timeZoneID,
@@ -35,7 +36,6 @@ struct CountdownRowView: View {
         )
         .environmentObject(theme)
         .contentShape(Rectangle())
-        .onTapGesture { onSelect(countdown) }
         .scaleEffect(isPressing ? 0.97 : 1)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isPressing)
         .onLongPressGesture(minimumDuration: 0.4, maximumDistance: 50, pressing: { pressing in
@@ -46,20 +46,36 @@ struct CountdownRowView: View {
             Haptics.light()
             onEdit(countdown)
         }
-        .listRowSeparator(.hidden)
-        .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
-        .listRowBackground(theme.theme.background)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            DeleteSwipeButton { onDelete(countdown) }
-        }
-        .swipeActions(edge: .leading, allowsFullSwipe: false) {
-            ArchiveSwipeButton(
-                { onArchiveToggle(countdown) },
-                label: countdown.isArchived ? "Unarchive" : "Archive",
-                systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox",
-                hint: countdown.isArchived ? "Restore countdown" : "Archive countdown"
+
+        if useHeroTransition {
+            styledRow(
+                card.onTapGesture { onSelect(countdown) }
+            )
+        } else {
+            styledRow(
+                NavigationLink(value: countdown.id) {
+                    card
+                }
             )
         }
     }
-}
 
+    @ViewBuilder
+    private func styledRow<Content: View>(_ content: Content) -> some View {
+        content
+            .listRowSeparator(.hidden)
+            .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
+            .listRowBackground(theme.theme.background)
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                DeleteSwipeButton { onDelete(countdown) }
+            }
+            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                ArchiveSwipeButton(
+                    { onArchiveToggle(countdown) },
+                    label: countdown.isArchived ? "Unarchive" : "Archive",
+                    systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox",
+                    hint: countdown.isArchived ? "Restore countdown" : "Archive countdown"
+                )
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- use NavigationLink for default countdown row navigation
- gate hero overlay transition behind `useHeroTransition`
- prepare NavigationStack path to support deep links
- ensure `navigationDestination` is applied within the stack

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68adf231c5648333b5f8241cb85faab0