### PR TITLE
Add crown and settings buttons with placeholder pages

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -16,6 +16,8 @@ struct CountdownListView: View {
     @State private var showShareSheet = false
     @State private var showPaywall = false
     @State private var showingBlankDetail = false
+    @State private var showCrownPage = false
+    @State private var showSettingsPage = false
     @Namespace private var heroNamespace
 
     var refreshAction: (() async -> Void)? = nil
@@ -26,7 +28,7 @@ struct CountdownListView: View {
                 theme.theme.background.ignoresSafeArea()
 
                 VStack(spacing: 0) {
-                    HeaderView()
+                    HeaderView(showCrownPage: $showCrownPage, showSettingsPage: $showSettingsPage)
                         .environmentObject(theme)
 
                     if items.isEmpty {
@@ -60,6 +62,18 @@ struct CountdownListView: View {
             .sheet(isPresented: $showAddEdit, content: addEditSheet)
             .sheet(isPresented: $showShareSheet, content: shareSheet)
             .sheet(isPresented: $showPaywall, content: paywallSheet)
+            .sheet(isPresented: $showCrownPage) {
+                NavigationStack {
+                    PlaceholderPageView(title: "Crown")
+                        .environmentObject(theme)
+                }
+            }
+            .sheet(isPresented: $showSettingsPage) {
+                NavigationStack {
+                    PlaceholderPageView(title: "Settings")
+                        .environmentObject(theme)
+                }
+            }
             .fullScreenCover(isPresented: $showingBlankDetail) {
                 blankDetailOverlay(isPresented: $showingBlankDetail, onClose: { showingBlankDetail = false })
             }
@@ -96,9 +110,22 @@ struct CountdownListView: View {
 
 private struct HeaderView: View {
     @EnvironmentObject private var theme: ThemeManager
+    @Binding var showCrownPage: Bool
+    @Binding var showSettingsPage: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Button { showCrownPage = true } label: {
+                    Image(systemName: "crown")
+                        .foregroundStyle(theme.theme.textPrimary)
+                }
+                Spacer()
+                Button { showSettingsPage = true } label: {
+                    Image(systemName: "gearshape")
+                        .foregroundStyle(theme.theme.textPrimary)
+                }
+            }
             Text("Countdowns")
                 .font(.largeTitle.bold())
                 .foregroundStyle(theme.theme.textPrimary)

--- a/CouplesCount/Views/PlaceholderPageView.swift
+++ b/CouplesCount/Views/PlaceholderPageView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct PlaceholderPageView: View {
+    @EnvironmentObject private var theme: ThemeManager
+    let title: String
+
+    var body: some View {
+        ZStack {
+            theme.theme.background
+                .ignoresSafeArea()
+        }
+        .navigationTitle(title)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PlaceholderPageView(title: "Preview")
+            .environmentObject(ThemeManager())
+    }
+}


### PR DESCRIPTION
## Summary
- Add crown and settings icons to the countdown list header.
- Each button opens a blank placeholder page for future content.

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af843d08288333bda1a8e0e50866d4