### PR TITLE
Redesign settings page with segmented theme picker

### DIFF
--- a/CouplesCount/Views/Settings/SettingsView.swift
+++ b/CouplesCount/Views/Settings/SettingsView.swift
@@ -1,125 +1,32 @@
 import SwiftUI
-import StoreKit
-import UIKit
 import SwiftData
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.openURL) private var openURL
     @EnvironmentObject private var theme: ThemeManager
-    @EnvironmentObject private var pro: ProStatusProvider
+    @Query(filter: #Predicate<Countdown> { $0.isArchived })
+    private var archivedItems: [Countdown]
 
-    private let themes: [ColorTheme] = [.light, .dark, .royalBlues, .barbie]
-    private let supportEmail = "support@couplescount.app"
-    @State private var activeAlert: ActiveAlert?
-    @State private var showEnjoyPrompt = false
-    @State private var showFeedbackForm = false
     @State private var showPaywall = false
 
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 18) {
-                    if !AppConfig.isStrictLight {
-                        SettingsCard {
-                            LazyVGrid(
-                                columns: [GridItem(.flexible(), spacing: 12),
-                                          GridItem(.flexible(), spacing: 12)],
-                                spacing: 12
-                            ) {
-                                ForEach(themes, id: \.self) { t in
-                                    let ent = Entitlements.current
-                                    let locked = AppConfig.entitlementsMode == .live && ((t == .dark && !ent.hasDarkMode) || (t != .light && t != .dark && !ent.hasPremiumThemes))
-                                    ThemeSwatch(theme: t, isSelected: t == theme.theme, isLocked: locked) {
-                                        if locked {
-                                            showPaywall = true
-                                        } else {
-                                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                            theme.setTheme(t)   // instant global update
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    appearanceSection
 
                     if AppConfig.entitlementsMode == .live && !Entitlements.current.isUnlimited {
-                        SettingsCard {
-                            SettingsButtonRow(icon: "crown.fill", title: "Go Pro") { showPaywall = true }
-#if DEBUG
-                            Divider().overlay(theme.theme.textPrimary.opacity(0.1))
-                            Toggle("Simulate Pro", isOn: $pro.debugIsPro)
-#endif
-                        }
+                        premiumSection
                     }
 
-                    // NOTIFICATIONS
-                    SettingsCard {
-                        SettingsButtonRow(icon: "bell.badge.fill", title: "Reminders") {
-                            activeAlert = .reminders
-                        }
-                    }
+                    archiveSection
 
-                    // ARCHIVE
-                    SettingsCard {
-                        NavigationLink {
-                            ArchiveView()
-                                .environmentObject(theme)
-                        } label: {
-                              HStack(spacing: 12) {
-                                  Image(systemName: "archivebox.fill")
-                                      .font(.title3)
-                                      .foregroundStyle(theme.theme.textPrimary)
-                                      .frame(width: 30, height: 30)
-                                      .background(
-                                          RoundedRectangle(cornerRadius: 8)
-                                              .fill(theme.theme.textPrimary.opacity(0.1))
-                                      )
-                                      .accessibilityHidden(true)
-                                  Text("Manage Archive")
-                                      .font(.body)
-                                      .foregroundStyle(theme.theme.textPrimary)
-                                  Spacer()
-                              }
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                    }
-
-                    // SUPPORT
-                    SectionHeader(text: "Support")
-                    SettingsCard {
-                        SettingsButtonRow(icon: "envelope.fill", title: "Contact Support") {
-                            if let url = URL(string: "mailto:\(supportEmail)") {
-                                openURL(url)
-                            }
-                        }
-                        Divider().overlay(theme.theme.textPrimary.opacity(0.1))
-                        SettingsButtonRow(icon: "star.fill", title: "Rate CouplesCount") {
-                            showEnjoyPrompt = true
-                        }
-                    }
-
-                    // ABOUT
-                    SectionHeader(text: "About")
-                    SettingsCard {
-                        SettingsKeyValueRow(
-                            key: "Version",
-                            value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
-                        )
-                        Divider().overlay(theme.theme.textPrimary.opacity(0.08))
-                        SettingsKeyValueRow(
-                            key: "Build",
-                            value: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
-                        )
-                    }
-
-                    Spacer(minLength: 20)
+                    footer
                 }
-                .padding(.top, 8)
+                .padding(.vertical, 20)
             }
             .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.textPrimary)            // default icons
+            .tint(theme.theme.textPrimary)
             .scrollIndicators(.hidden)
             .navigationTitle("Settings")
             .toolbarColorScheme(theme.theme == .light ? .light : .dark, for: .navigationBar)
@@ -127,43 +34,141 @@ struct SettingsView: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
             }
         }
-        .alert(item: $activeAlert) { alert in
-            switch alert {
-            case .reminders:
-                return Alert(
-                    title: Text("Coming Soon"),
-                    message: Text("Configure reminders coming soon."),
-                    dismissButton: .default(Text("OK"))
-                )
-            }
-        }
-        .confirmationDialog(
-            "Are you enjoying the app so far?",
-            isPresented: $showEnjoyPrompt,
-            titleVisibility: .visible
-        ) {
-            Button("Yes") {
-                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                    AppStore.requestReview(in: scene)
-                }
-            }
-            Button("No") { showFeedbackForm = true }
-            Button("Cancel", role: .cancel) {}
-        }
-        .sheet(isPresented: $showFeedbackForm) {
-            FeedbackFormView()
-                .environmentObject(theme)
-        }
         .sheet(isPresented: $showPaywall) {
             PaywallView()
                 .environmentObject(theme)
         }
     }
-
 }
 
-private enum ActiveAlert: Identifiable {
-    case reminders
+private extension SettingsView {
+    var appearanceSection: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 12) {
+                    Image(systemName: "paintpalette.fill")
+                        .font(.title3)
+                        .foregroundStyle(theme.theme.textPrimary)
+                        .frame(width: 30, height: 30)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(theme.theme.textPrimary.opacity(0.1))
+                        )
+                        .accessibilityHidden(true)
 
-    var id: Int { hashValue }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Appearance")
+                            .font(.body)
+                            .foregroundStyle(theme.theme.textPrimary)
+                        Text("Choose your preferred theme")
+                            .font(.footnote)
+                            .foregroundStyle(theme.theme.textSecondary)
+                    }
+
+                    Spacer()
+                }
+
+                Picker(
+                    "Appearance",
+                    selection: Binding(
+                        get: { theme.theme },
+                        set: { theme.setTheme($0) }
+                    )
+                ) {
+                    Text("Light").tag(ColorTheme.light)
+                    Text("Dark").tag(ColorTheme.dark)
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+    }
+
+    var premiumSection: some View {
+        SettingsCard {
+            Button(action: { showPaywall = true }) {
+                HStack(spacing: 12) {
+                    Image(systemName: "crown.fill")
+                        .font(.title3)
+                        .foregroundStyle(theme.theme.textPrimary)
+                        .frame(width: 30, height: 30)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(theme.theme.textPrimary.opacity(0.1))
+                        )
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Premium")
+                            .font(.body)
+                            .foregroundStyle(theme.theme.textPrimary)
+                        Text("Unlock unlimited countdowns and features")
+                            .font(.footnote)
+                            .foregroundStyle(theme.theme.textSecondary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(theme.theme.textSecondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    var archiveSection: some View {
+        SettingsCard {
+            NavigationLink {
+                ArchiveView()
+                    .environmentObject(theme)
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "archivebox.fill")
+                        .font(.title3)
+                        .foregroundStyle(theme.theme.textPrimary)
+                        .frame(width: 30, height: 30)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(theme.theme.textPrimary.opacity(0.1))
+                        )
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Archive")
+                            .font(.body)
+                            .foregroundStyle(theme.theme.textPrimary)
+                        Text("\(archivedItems.count) completed countdowns")
+                            .font(.footnote)
+                            .foregroundStyle(theme.theme.textSecondary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(theme.theme.textSecondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    var footer: some View {
+        VStack(spacing: 4) {
+            Text("Countdowns")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(theme.theme.textSecondary)
+            Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")")
+                .font(.footnote)
+                .foregroundStyle(theme.theme.textSecondary)
+            Text("Made with ❤️ for shared moments")
+                .font(.footnote)
+                .foregroundStyle(theme.theme.textSecondary)
+        }
+        .padding(.top, 12)
+    }
 }
+


### PR DESCRIPTION
## Summary
- Simplify SettingsView to match new design
- Provide theme selector for light and dark modes
- Show Premium and Archive cards with dynamic archive count

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af88c445ac8333b4d7d1c994545f83