### PR TITLE
Add light/dark theme system with semantic color tokens

### DIFF
--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import SwiftData
 
 struct ContentView: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     @Environment(\.modelContext) private var modelContext
     @State private var importError: String?
 
@@ -18,7 +18,7 @@ struct ContentView: View {
                     Label("Profile", systemImage: "person.crop.circle")
                 }
         }
-        .tint(theme.theme.textPrimary)
+        .tint(theme.color(.Primary))
         .onOpenURL { url in
             do {
                 try CountdownShareService.importCountdown(from: url, context: modelContext)

--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -17,6 +17,7 @@ struct CouplesCountApp: App {
         if AppConfig.isStrictLight {
             themeManager.setTheme(.light)
         }
+        ThemeDevLog.log()
     }
 
     var body: some Scene {
@@ -55,6 +56,7 @@ struct CouplesCountApp: App {
                 }
             }
             .preferredColorScheme(AppConfig.isStrictLight ? .light : nil)
+            .applyTheme()
         }
     }
 }

--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -3,8 +3,9 @@ import SwiftData
 import UIKit
 
 struct CountdownListView: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @EnvironmentObject private var themeManager: ThemeManager
     @EnvironmentObject private var pro: ProStatusProvider
+    @Environment(\.theme) private var theme
 
     @Query(filter: #Predicate<Countdown> { !$0.isArchived },
            sort: \.targetUTC, order: .forward)
@@ -24,11 +25,10 @@ struct CountdownListView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                theme.theme.background.ignoresSafeArea()
+                theme.color(.Background).ignoresSafeArea()
 
                 VStack(spacing: 0) {
                     HeaderView(showPaywall: $showPaywall, showSettingsPage: $showSettingsPage)
-                        .environmentObject(theme)
 
                     if items.isEmpty {
                         EmptyStateView()
@@ -56,20 +56,19 @@ struct CountdownListView: View {
                     showPaywall: $showPaywall,
                     editing: $editing
                 )
-                .environmentObject(theme)
             }
             .sheet(isPresented: $showAddEdit, content: addEditSheet)
             .sheet(isPresented: $showShareSheet, content: shareSheet)
             .fullScreenCover(isPresented: $showPaywall, content: paywallSheet)
             .sheet(isPresented: $showSettingsPage) {
                 SettingsView()
-                    .environmentObject(theme)
+                    .environmentObject(themeManager)
             }
             .fullScreenCover(isPresented: $showingBlankDetail) {
                 blankDetailOverlay(isPresented: $showingBlankDetail, onClose: { showingBlankDetail = false })
             }
         }
-        .tint(theme.theme.textPrimary)
+        .tint(theme.color(.Primary))
     }
 
     // MARK: - Overlays & Sheets
@@ -77,12 +76,12 @@ struct CountdownListView: View {
     @ViewBuilder
     private func blankDetailOverlay(isPresented _: Binding<Bool>, onClose _: () -> Void) -> some View {
         BlankDetailView()
-            .environmentObject(theme)
+            .environmentObject(themeManager)
     }
 
     private func addEditSheet() -> some View {
         AddEditCountdownView(existing: editing)
-            .environmentObject(theme)
+            .environmentObject(themeManager)
             .environmentObject(pro)
     }
 
@@ -95,12 +94,12 @@ struct CountdownListView: View {
 
     private func paywallSheet() -> some View {
         PaywallView()
-            .environmentObject(theme)
+            .environmentObject(themeManager)
     }
 }
 
 private struct HeaderView: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     @Binding var showPaywall: Bool
     @Binding var showSettingsPage: Bool
 
@@ -109,17 +108,17 @@ private struct HeaderView: View {
             HStack {
                 Button { showPaywall = true } label: {
                     Image(systemName: "crown")
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                 }
                 Spacer()
                 Button { showSettingsPage = true } label: {
                     Image(systemName: "gearshape")
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                 }
             }
             Text("Countdowns")
                 .font(.largeTitle.bold())
-                .foregroundStyle(theme.theme.textPrimary)
+                .foregroundStyle(theme.color(.Foreground))
             Text("Shared moments with loved ones")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -147,7 +146,7 @@ private struct EmptyStateView: View {
 }
 
 private struct AddButton: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     let itemCount: Int
     @Binding var showAddEdit: Bool
     @Binding var showPaywall: Bool
@@ -167,8 +166,8 @@ private struct AddButton: View {
                 Image(systemName: "plus")
                     .font(.title)
                     .padding(20)
-                    .background(Circle().fill(theme.theme.primary))
-                    .foregroundStyle(Color.white)
+                    .background(Circle().fill(theme.color(.Primary)))
+                    .foregroundStyle(theme.color(.PrimaryForeground))
                     .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
                     .frame(minWidth: 44, minHeight: 44)
                     .contentShape(Rectangle())

--- a/CouplesCount/Views/OnboardingView.swift
+++ b/CouplesCount/Views/OnboardingView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct OnboardingView: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     /// Called when notification access is denied so the host can present guidance.
     let onDenied: () -> Void
@@ -13,8 +13,8 @@ struct OnboardingView: View {
             finalSlide
         }
         .tabViewStyle(.page)
-        .background(theme.theme.background.ignoresSafeArea())
-        .tint(theme.theme.textPrimary)
+        .background(theme.color(.Background).ignoresSafeArea())
+        .tint(theme.color(.Primary))
     }
 
     @ViewBuilder
@@ -25,12 +25,12 @@ struct OnboardingView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 120, height: 120)
-                .foregroundStyle(theme.theme.textPrimary)
+                .foregroundStyle(theme.color(.Foreground))
                 .accessibilityHidden(true)
             Text(text)
                 .font(.title2)
                 .multilineTextAlignment(.center)
-                .foregroundStyle(theme.theme.textPrimary)
+                .foregroundStyle(theme.color(.Foreground))
                 .padding(.top, 24)
                 .padding(.horizontal)
             Spacer()
@@ -45,21 +45,21 @@ struct OnboardingView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 120, height: 120)
-                .foregroundStyle(theme.theme.primary)
+                .foregroundStyle(theme.color(.Primary))
                 .accessibilityHidden(true)
             Text("Share with your partner.")
                 .font(.title2)
                 .multilineTextAlignment(.center)
-                .foregroundStyle(theme.theme.textPrimary)
+                .foregroundStyle(theme.color(.Foreground))
                 .padding(.top, 24)
                 .padding(.horizontal)
             Button(action: finishOnboarding) {
                 Text("Done")
                     .font(.headline)
-                    .foregroundStyle(Color.white)
+                    .foregroundStyle(theme.color(.PrimaryForeground))
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.theme.primary))
+                    .background(RoundedRectangle(cornerRadius: 12).fill(theme.color(.Primary)))
             }
             .padding(.top, 32)
             .padding(.horizontal)
@@ -78,7 +78,12 @@ struct OnboardingView: View {
     }
 }
 
-#Preview {
+#Preview("Light") {
     OnboardingView(onDenied: {})
-        .environmentObject(ThemeManager())
+        .environment(\.theme, Theme(colorScheme: .light))
+}
+
+#Preview("Dark") {
+    OnboardingView(onDenied: {})
+        .environment(\.theme, Theme(colorScheme: .dark))
 }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -3,7 +3,8 @@ import SwiftData
 import UIKit
 
 struct ProfileView: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.theme) private var theme
     @Environment(\.modelContext) private var modelContext
     @Query(filter: #Predicate<Countdown> { $0.isShared && !$0.isArchived },
            sort: \Countdown.targetUTC, order: .forward)
@@ -32,12 +33,12 @@ struct ProfileView: View {
                                 Image(systemName: "person.crop.circle.fill")
                                     .resizable()
                                     .scaledToFit()
-                                    .foregroundColor(.gray)
+                                    .foregroundStyle(theme.color(.MutedForeground))
                                     .padding(4)
                             }
                         }
                         .frame(width: 80, height: 80)
-                        .background(Color.gray.opacity(profileImageData == nil ? 0.2 : 0))
+                        .background(theme.color(.Muted).opacity(profileImageData == nil ? 0.2 : 0))
                         .clipShape(Circle())
                     }
                     .accessibilityLabel("Profile photo")
@@ -112,7 +113,7 @@ struct ProfileView: View {
                             shared: item.isShared,
                             shareAction: nil
                         )
-                        .environmentObject(theme)
+                        .environmentObject(themeManager)
                         .contextMenu {
                             DeleteSwipeButton({
                                 withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
@@ -141,6 +142,6 @@ struct ProfileView: View {
                 .animation(.spring(response: 0.4, dampingFraction: 0.85), value: shared)
             }
         }
-        .background(theme.theme.background.ignoresSafeArea())
+        .background(theme.color(.Background).ignoresSafeArea())
     }
 }

--- a/Shared/Colors.xcassets/Accent.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Accent.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#e9ebef",
+    "dark": "dark:oklch(0.269 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.914",
+          "green": "0.922",
+          "blue": "0.937",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.149",
+          "green": "0.149",
+          "blue": "0.149",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/AccentForeground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/AccentForeground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#030213",
+    "dark": "dark:oklch(0.985 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.012",
+          "green": "0.008",
+          "blue": "0.075",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.980",
+          "green": "0.980",
+          "blue": "0.980",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Background.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Background.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#ffffff",
+    "dark": "dark:oklch(0.145 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "1.000",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.039",
+          "green": "0.039",
+          "blue": "0.039",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Border.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Border.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:rgba(0,0,0,0.1)",
+    "dark": "dark:oklch(0.269 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.000",
+          "green": "0.000",
+          "blue": "0.000",
+          "alpha": "0.100"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.149",
+          "green": "0.149",
+          "blue": "0.149",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Card.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Card.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#ffffff",
+    "dark": "dark:oklch(0.145 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "1.000",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.039",
+          "green": "0.039",
+          "blue": "0.039",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/CardForeground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/CardForeground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.145 0 0)",
+    "dark": "dark:oklch(0.985 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.039",
+          "green": "0.039",
+          "blue": "0.039",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.980",
+          "green": "0.980",
+          "blue": "0.980",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Chart1.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Chart1.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.646 0.222 41.116)",
+    "dark": "dark:oklch(0.488 0.243 264.376)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.961",
+          "green": "0.286",
+          "blue": "0.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.078",
+          "green": "0.278",
+          "blue": "0.902",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Chart2.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Chart2.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.6 0.118 184.704)",
+    "dark": "dark:oklch(0.696 0.17 162.48)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.000",
+          "green": "0.588",
+          "blue": "0.537",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.000",
+          "green": "0.737",
+          "blue": "0.490",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Chart3.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Chart3.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.398 0.07 227.392)",
+    "dark": "dark:oklch(0.769 0.188 70.08)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.063",
+          "green": "0.306",
+          "blue": "0.392",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.996",
+          "green": "0.604",
+          "blue": "0.000",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Chart4.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Chart4.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.828 0.189 84.429)",
+    "dark": "dark:oklch(0.627 0.265 303.9)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "0.725",
+          "blue": "0.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.678",
+          "green": "0.275",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Chart5.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Chart5.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.769 0.188 70.08)",
+    "dark": "dark:oklch(0.645 0.246 16.439)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.996",
+          "green": "0.604",
+          "blue": "0.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "0.125",
+          "blue": "0.337",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Contents.json
+++ b/Shared/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Shared/Colors.xcassets/Destructive.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Destructive.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#d4183d",
+    "dark": "dark:oklch(0.396 0.141 25.723)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.831",
+          "green": "0.094",
+          "blue": "0.239",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.510",
+          "green": "0.094",
+          "blue": "0.102",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/DestructiveForeground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/DestructiveForeground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#ffffff",
+    "dark": "dark:oklch(0.637 0.237 25.331)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "1.000",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.984",
+          "green": "0.173",
+          "blue": "0.212",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Foreground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Foreground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.145 0 0)",
+    "dark": "dark:oklch(0.985 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.039",
+          "green": "0.039",
+          "blue": "0.039",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.980",
+          "green": "0.980",
+          "blue": "0.980",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/InputBackground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/InputBackground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#f3f3f5",
+    "dark": "dark:oklch(0.269 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.953",
+          "green": "0.953",
+          "blue": "0.961",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.149",
+          "green": "0.149",
+          "blue": "0.149",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Muted.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Muted.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#ececf0",
+    "dark": "dark:oklch(0.269 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.925",
+          "green": "0.925",
+          "blue": "0.941",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.149",
+          "green": "0.149",
+          "blue": "0.149",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/MutedForeground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/MutedForeground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#717182",
+    "dark": "dark:oklch(0.708 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.443",
+          "green": "0.443",
+          "blue": "0.510",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.631",
+          "green": "0.631",
+          "blue": "0.631",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Popover.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Popover.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(1 0 0)",
+    "dark": "dark:oklch(0.145 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "1.000",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.039",
+          "green": "0.039",
+          "blue": "0.039",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/PopoverForeground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/PopoverForeground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.145 0 0)",
+    "dark": "dark:oklch(0.985 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.039",
+          "green": "0.039",
+          "blue": "0.039",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.980",
+          "green": "0.980",
+          "blue": "0.980",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Primary.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Primary.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#030213",
+    "dark": "dark:oklch(0.985 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.012",
+          "green": "0.008",
+          "blue": "0.075",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.980",
+          "green": "0.980",
+          "blue": "0.980",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/PrimaryForeground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/PrimaryForeground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(1 0 0)",
+    "dark": "dark:oklch(0.205 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "1.000",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.090",
+          "green": "0.090",
+          "blue": "0.090",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Ring.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Ring.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.708 0 0)",
+    "dark": "dark:oklch(0.439 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.631",
+          "green": "0.631",
+          "blue": "0.631",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.322",
+          "green": "0.322",
+          "blue": "0.322",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/Secondary.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Secondary.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:oklch(0.95 0.0058 264.53)",
+    "dark": "dark:oklch(0.269 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.925",
+          "green": "0.933",
+          "blue": "0.949",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.149",
+          "green": "0.149",
+          "blue": "0.149",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/SecondaryForeground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/SecondaryForeground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#030213",
+    "dark": "dark:oklch(0.985 0 0)"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.012",
+          "green": "0.008",
+          "blue": "0.075",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.980",
+          "green": "0.980",
+          "blue": "0.980",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Colors.xcassets/SwitchBackground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/SwitchBackground.colorset/Contents.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode",
+    "light": "light:#cbced4",
+    "dark": "dark:muted"
+  },
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.796",
+          "green": "0.808",
+          "blue": "0.831",
+          "alpha": "1.000"
+        }
+      }
+    },
+    {
+      "idiom": "universal",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.149",
+          "green": "0.149",
+          "blue": "0.149",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Shared/Theme/Theme.swift
+++ b/Shared/Theme/Theme.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Semantic color tokens backed by Colors.xcassets
+public enum ThemeColor: String, CaseIterable {
+    case Background, Foreground, Card, CardForeground, Popover, PopoverForeground
+    case Primary, PrimaryForeground, Secondary, SecondaryForeground
+    case Muted, MutedForeground, Accent, AccentForeground
+    case Destructive, DestructiveForeground, Border
+    case InputBackground, SwitchBackground, Ring
+    case Chart1, Chart2, Chart3, Chart4, Chart5
+}
+
+/// Typography tokens using the system font and supporting Dynamic Type
+public struct Typography {
+    public enum Style {
+        case largeTitle, title, headline, body, caption
+    }
+
+    public func font(_ style: Style) -> Font {
+        switch style {
+        case .largeTitle: return .system(.largeTitle, design: .default)
+        case .title: return .system(.title, design: .default)
+        case .headline: return .system(.headline, design: .default)
+        case .body: return .system(.body, design: .default)
+        case .caption: return .system(.caption, design: .default)
+        }
+    }
+}
+
+/// Corner radii derived from a 10pt base radius (0.625rem)
+public struct Corners {
+    private let base: CGFloat = 10
+    public var sm: CGFloat { base / 2 }
+    public var md: CGFloat { base }
+    public var lg: CGFloat { base * 1.5 }
+    public var xl: CGFloat { base * 2 }
+}
+
+/// Theme container providing access to colors, typography and radii
+public struct Theme {
+    public let colorScheme: ColorScheme
+    public let typography = Typography()
+    public let corners = Corners()
+
+    public func color(_ token: ThemeColor) -> Color {
+        Color(token.rawValue, bundle: .main)
+    }
+
+    public static func current(_ scheme: ColorScheme) -> Theme {
+        Theme(colorScheme: scheme)
+    }
+}
+
+private struct ThemeKey: EnvironmentKey {
+    static let defaultValue = Theme(colorScheme: .light)
+}
+
+public extension EnvironmentValues {
+    var theme: Theme {
+        get { self[ThemeKey.self] }
+        set { self[ThemeKey.self] = newValue }
+    }
+}
+
+private struct ThemeProvider: ViewModifier {
+    @Environment(\.colorScheme) private var scheme
+    func body(content: Content) -> some View {
+        content.environment(\.theme, Theme.current(scheme))
+    }
+}
+
+public extension View {
+    /// Injects a Theme derived from the current colorScheme
+    func applyTheme() -> some View {
+        modifier(ThemeProvider())
+    }
+}

--- a/Shared/Theme/ThemeDevLog.swift
+++ b/Shared/Theme/ThemeDevLog.swift
@@ -1,0 +1,13 @@
+#if DEBUG
+import Foundation
+
+enum ThemeDevLog {
+    static func log() {
+        let colors = 25
+        let updated = ["ContentView", "ProfileView", "CountdownListView"].joined(separator: ", ")
+        let approximated = ["Foreground", "Secondary", "Ring", "Destructive (dark)", "DestructiveForeground (dark)"]
+            .joined(separator: ", ")
+        print("Theme setup: \(colors) colors, updated: \(updated), approximated: \(approximated)")
+    }
+}
+#endif

--- a/Shared/Theme/ThemePreview.swift
+++ b/Shared/Theme/ThemePreview.swift
@@ -1,0 +1,66 @@
+#if DEBUG
+import SwiftUI
+
+/// Simple developer screen to inspect theme colors
+struct ThemePreviewView: View {
+    @State private var scheme: ColorScheme = .light
+
+    private var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
+
+    var body: some View {
+        let theme = Theme(colorScheme: scheme)
+        NavigationView {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(ThemeColor.allCases, id: \.self) { token in
+                        SwatchView(token: token)
+                            .frame(height: 44)
+                            .background(theme.color(token))
+                            .cornerRadius(theme.corners.sm)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Theme Preview")
+            .toolbar {
+                Toggle("Dark", isOn: Binding(
+                    get: { scheme == .dark },
+                    set: { scheme = $0 ? .dark : .light }
+                ))
+            }
+        }
+        .environment(\.theme, theme)
+    }
+}
+
+private struct SwatchView: View {
+    @Environment(\.theme) private var theme
+    let token: ThemeColor
+
+    var body: some View {
+        ZStack {
+            theme.color(token)
+            Text(token.rawValue)
+                .font(theme.typography.font(.caption))
+                .foregroundStyle(theme.color(.Foreground))
+        }
+        .clipShape(RoundedRectangle(cornerRadius: theme.corners.sm))
+    }
+}
+
+#Preview("Light") {
+    ThemePreviewView()
+        .environment(\.theme, Theme(colorScheme: .light))
+}
+
+#Preview("Dark") {
+    ThemePreviewView()
+        .environment(\.theme, Theme(colorScheme: .dark))
+}
+
+#Preview("XL") {
+    ThemePreviewView()
+        .environment(\.theme, Theme(colorScheme: .light))
+        .environment(\.sizeCategory, .accessibilityExtraLarge)
+}
+#endif


### PR DESCRIPTION
## Summary
- add `Theme` type with typed semantic color accessors, typography, and corner radii
- introduce `Colors.xcassets` containing light and dark variants for 25 semantic colors
- wire up environment-based theming across main views and add developer preview screen
- fix header color reference in countdown list to use new theme API

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68af8f61e8308333a686f0a8a92f4bc8