### PR TITLE
Add system theme toggle using semantic colors

### DIFF
--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -5,6 +5,7 @@ import SwiftData
 struct CouplesCountApp: App {
     @StateObject private var pro: ProStatusProvider
     @StateObject private var theme: ThemeManager
+    @StateObject private var themeSettings = ThemeSettings()
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     @State private var showDeniedInfo = false
 
@@ -27,6 +28,7 @@ struct CouplesCountApp: App {
                     ContentView()
                         .environmentObject(theme)
                         .environmentObject(pro)
+                        .environmentObject(themeSettings)
                         // Use a custom container so the widget and app share data
                         .modelContainer(Persistence.container)
                 } else {
@@ -35,6 +37,7 @@ struct CouplesCountApp: App {
                     }
                     .environmentObject(theme)
                     .environmentObject(pro)
+                    .environmentObject(themeSettings)
                 }
             }
             .sheet(isPresented: $showDeniedInfo) {
@@ -56,7 +59,7 @@ struct CouplesCountApp: App {
                 }
             }
             .preferredColorScheme(
-                AppConfig.isStrictLight ? .light : theme.theme.colorScheme
+                AppConfig.isStrictLight ? .light : themeSettings.selection.colorScheme
             )
 
             .applyTheme()

--- a/CouplesCount/Views/Countdowns/AddEdit/AddEditCountdownView.swift
+++ b/CouplesCount/Views/Countdowns/AddEdit/AddEditCountdownView.swift
@@ -4,7 +4,8 @@ import SwiftData
 struct AddEditCountdownView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
 
     let existing: Countdown?
 
@@ -102,7 +103,7 @@ struct AddEditCountdownView: View {
                             } label: {
                                 Label(existing.isArchived ? "Unarchive Countdown" : "Archive Countdown",
                                       systemImage: existing.isArchived ? "tray.and.arrow.up" : "archivebox")
-                                    .foregroundStyle(theme.theme.textPrimary)
+                                    .foregroundStyle(theme.color(.Foreground))
                             }
                         }
 
@@ -119,7 +120,7 @@ struct AddEditCountdownView: View {
                                 dismiss()
                             } label: {
                                 Label("Delete Countdown", systemImage: "trash")
-                                    .foregroundStyle(theme.theme.textPrimary)
+                                    .foregroundStyle(theme.color(.Foreground))
                             }
                         }
                     }
@@ -135,21 +136,21 @@ struct AddEditCountdownView: View {
                     .padding(.vertical, 8)
                     .padding(.trailing, 2)
             }
-            .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.textPrimary)
+            .background(theme.color(.Background).ignoresSafeArea())
+            .tint(theme.color(.Primary))
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(theme.theme == .light ? .light : .dark, for: .navigationBar)
-            .toolbarBackground(theme.theme.background, for: .navigationBar)
+            .toolbarColorScheme(colorScheme, for: .navigationBar)
+            .toolbarBackground(theme.color(.Background), for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                 }
                 ToolbarItem(placement: .principal) {
                     Text(existing == nil ? "Add Countdown" : "Edit Countdown")
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     HStack {
@@ -163,7 +164,7 @@ struct AddEditCountdownView: View {
                                     .contentShape(Rectangle())
                                     .accessibilityLabel("Share")
                                     .accessibilityHint("Share countdown")
-                                    .foregroundStyle(theme.theme.textPrimary)
+                                    .foregroundStyle(theme.color(.Foreground))
                             }
                         }
                         Button(action: save) {
@@ -172,7 +173,7 @@ struct AddEditCountdownView: View {
                                 .contentShape(Rectangle())
                                 .accessibilityLabel("Save")
                                 .accessibilityHint("Save countdown")
-                                .foregroundStyle(theme.theme.textPrimary)
+                                .foregroundStyle(theme.color(.Foreground))
                         }
                         .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
@@ -198,7 +199,7 @@ struct AddEditCountdownView: View {
                 if new != nil { Haptics.light() }
             }
             .onAppear {
-                let defaultHex = theme.theme.primary.hexString
+                let defaultHex = theme.color(.Primary).hexString
                 if let existing {
                     title = existing.title
                     date = existing.targetDate
@@ -229,7 +230,7 @@ struct AddEditCountdownView: View {
                 }
             }
         }
-        .tint(theme.theme.textPrimary)
+        .tint(theme.color(.Primary))
         .alert("Couldn’t Save",
                isPresented: Binding(get: { saveError != nil },
                                    set: { if !$0 { saveError = nil } })) {
@@ -246,7 +247,7 @@ struct AddEditCountdownView: View {
         guard !trimmed.isEmpty else { showValidation = true; return }
 
         do {
-            let defaultHex = theme.theme.primary.hexString.uppercased()
+            let defaultHex = theme.color(.Primary).hexString.uppercased()
             let chosenHex = colorHex.uppercased()
             let storedHex: String? = (chosenHex == defaultHex) ? nil : chosenHex
 

--- a/CouplesCount/Views/Countdowns/AddEdit/BackgroundPickerSection.swift
+++ b/CouplesCount/Views/Countdowns/AddEdit/BackgroundPickerSection.swift
@@ -4,7 +4,7 @@ import AVFoundation
 import UIKit
 
 struct BackgroundPickerSection: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     @Binding var backgroundStyle: String
     @Binding var colorHex: String
     @Binding var imageData: Data?
@@ -16,7 +16,7 @@ struct BackgroundPickerSection: View {
         SettingsCard {
             Text("Background")
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(theme.theme.textSecondary)
+                .foregroundStyle(theme.color(.MutedForeground))
 
             Picker("Style", selection: $backgroundStyle) {
                 Text("Color").tag("color")
@@ -31,7 +31,7 @@ struct BackgroundPickerSection: View {
                             .fill(Color(hex: hex) ?? .blue)
                             .frame(width: 32, height: 32)
                             .overlay(
-                                Circle().stroke(theme.theme.textPrimary.opacity(colorHex == hex ? 0.9 : 0), lineWidth: 2)
+                                Circle().stroke(theme.color(.Foreground).opacity(colorHex == hex ? 0.9 : 0), lineWidth: 2)
                             )
                             .onTapGesture { colorHex = hex }
                     }
@@ -52,7 +52,7 @@ struct BackgroundPickerSection: View {
                         .accessibilityHidden(true)
                 } else {
                     Text("No image selected")
-                        .foregroundStyle(theme.theme.textSecondary)
+                        .foregroundStyle(theme.color(.MutedForeground))
                 }
 
                 HStack(spacing: 12) {
@@ -79,12 +79,12 @@ struct BackgroundPickerSection: View {
     @ViewBuilder
     private func labelButton(_ title: String, system: String) -> some View {
         Label(title, systemImage: system)
-            .foregroundStyle(theme.theme.textPrimary)
+            .foregroundStyle(theme.color(.Foreground))
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
             .background(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(theme.theme.textPrimary.opacity(0.1))
+                    .fill(theme.color(.Foreground).opacity(0.1))
             )
     }
 }

--- a/CouplesCount/Views/Countdowns/AddEdit/CountdownFormFields.swift
+++ b/CouplesCount/Views/Countdowns/AddEdit/CountdownFormFields.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CountdownFormFields: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     @Binding var title: String
     @Binding var date: Date
     @Binding var timeZoneID: String
@@ -9,8 +9,8 @@ struct CountdownFormFields: View {
 
     var body: some View {
         SettingsCard {
-            TextField("", text: $title, prompt: Text("Title (e.g., Anniversary)").foregroundStyle(theme.theme.textSecondary))
-                .foregroundStyle(theme.theme.textPrimary)
+            TextField("", text: $title, prompt: Text("Title (e.g., Anniversary)").foregroundStyle(theme.color(.MutedForeground)))
+                .foregroundStyle(theme.color(.Foreground))
                 .textInputAutocapitalization(.words)
                 .onSubmit { Haptics.light() }
 
@@ -24,10 +24,10 @@ struct CountdownFormFields: View {
 
             HStack {
                 DatePicker("Date", selection: $date, displayedComponents: .date)
-                    .foregroundStyle(theme.theme.textPrimary)
+                    .foregroundStyle(theme.color(.Foreground))
                 DatePicker("", selection: $date, displayedComponents: .hourAndMinute)
                     .labelsHidden()
-                    .foregroundStyle(theme.theme.textPrimary)
+                    .foregroundStyle(theme.color(.Foreground))
             }
 
             NavigationLink {
@@ -35,10 +35,10 @@ struct CountdownFormFields: View {
             } label: {
                 HStack {
                     Text("Time Zone")
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                     Spacer()
                     Text(TimeZone(identifier: timeZoneID)?.identifier ?? "System")
-                        .foregroundStyle(theme.theme.textSecondary)
+                        .foregroundStyle(theme.color(.MutedForeground))
                 }
             }
         }

--- a/CouplesCount/Views/Countdowns/AddEdit/ReminderPickerSection.swift
+++ b/CouplesCount/Views/Countdowns/AddEdit/ReminderPickerSection.swift
@@ -28,7 +28,7 @@ enum ReminderOption: Int, CaseIterable, Identifiable {
 }
 
 struct ReminderPickerSection: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     @Binding var selectedReminders: Set<ReminderOption>
     @State private var showReminderSheet = false
 
@@ -37,13 +37,13 @@ struct ReminderPickerSection: View {
             HStack {
                 Text("Reminders")
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(theme.theme.textSecondary)
+                    .foregroundStyle(theme.color(.MutedForeground))
                 Spacer()
                 Button("+ Add Reminder") {
                     NotificationManager.requestAuthorizationIfNeeded()
                     showReminderSheet = true
                 }
-                .foregroundStyle(theme.theme.textPrimary)
+                .foregroundStyle(theme.color(.Foreground))
             }
 
             if !selectedReminders.isEmpty {
@@ -51,14 +51,14 @@ struct ReminderPickerSection: View {
                     ForEach(Array(selectedReminders).sorted { $0.rawValue < $1.rawValue }, id: \.self) { opt in
                         HStack(spacing: 4) {
                             Text(opt.label)
-                                .foregroundStyle(theme.theme.textPrimary)
+                                .foregroundStyle(theme.color(.Foreground))
                             Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(theme.theme.textSecondary)
+                                .foregroundStyle(theme.color(.MutedForeground))
                                 .onTapGesture { selectedReminders.remove(opt) }
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(theme.theme.textPrimary.opacity(0.1))
+                        .background(theme.color(.Foreground).opacity(0.1))
                         .clipShape(Capsule())
                     }
                 }
@@ -67,14 +67,14 @@ struct ReminderPickerSection: View {
         }
         .sheet(isPresented: $showReminderSheet) {
             ReminderPicker(selections: $selectedReminders)
-                .environmentObject(theme)
         }
     }
 }
 
 struct ReminderPicker: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
     @Binding var selections: Set<ReminderOption>
     @State private var temp: Set<ReminderOption>
 
@@ -90,13 +90,13 @@ struct ReminderPicker: View {
                     ForEach(ReminderOption.allCases) { option in
                         let isSel = temp.contains(option)
                         Text(option.label)
-                            .foregroundStyle(theme.theme.textPrimary)
+                            .foregroundStyle(theme.color(.Foreground))
                             .frame(maxWidth: .infinity, minHeight: 44)
-                            .background(isSel ? theme.theme.textPrimary.opacity(0.2) : theme.theme.textPrimary.opacity(0.1))
+                            .background(isSel ? theme.color(.Foreground).opacity(0.2) : theme.color(.Foreground).opacity(0.1))
                             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 8)
-                                    .stroke(isSel ? theme.theme.textPrimary : .clear, lineWidth: 2)
+                                    .stroke(isSel ? theme.color(.Foreground) : .clear, lineWidth: 2)
                             )
                             .onTapGesture {
                                 if isSel { temp.remove(option) } else { temp.insert(option) }
@@ -105,24 +105,24 @@ struct ReminderPicker: View {
                 }
                 .padding()
             }
-            .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.textPrimary)
+            .background(theme.color(.Background).ignoresSafeArea())
+            .tint(theme.color(.Primary))
             .navigationTitle("Reminders")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(theme.theme == .light ? .light : .dark, for: .navigationBar)
-            .toolbarBackground(theme.theme.background, for: .navigationBar)
+            .toolbarColorScheme(colorScheme, for: .navigationBar)
+            .toolbarBackground(theme.color(.Background), for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     Text("Reminders")
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
                         selections = temp
                         dismiss()
                     }
-                    .foregroundStyle(theme.theme.textPrimary)
+                    .foregroundStyle(theme.color(.Foreground))
                 }
             }
         }

--- a/CouplesCount/Views/Countdowns/AddEdit/ShareSection.swift
+++ b/CouplesCount/Views/Countdowns/AddEdit/ShareSection.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ShareSection: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     @Binding var isShared: Bool
     @Binding var selectedFriends: Set<UUID>
     var friends: [Friend]
@@ -9,7 +9,7 @@ struct ShareSection: View {
     var body: some View {
         SettingsCard {
             Toggle("Shared countdown", isOn: $isShared)
-                .foregroundStyle(theme.theme.textPrimary)
+                .foregroundStyle(theme.color(.Foreground))
             if isShared {
                 ForEach(friends) { friend in
                     let isSelected = Binding<Bool>(
@@ -19,7 +19,7 @@ struct ShareSection: View {
                         }
                     )
                     Toggle(friend.name, isOn: isSelected)
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                 }
             }
         }

--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -5,6 +5,7 @@ import UIKit
 struct CountdownListView: View {
     @EnvironmentObject private var themeManager: ThemeManager
     @EnvironmentObject private var pro: ProStatusProvider
+    @EnvironmentObject private var themeSettings: ThemeSettings
     @Environment(\.theme) private var theme
 
     @Query(filter: #Predicate<Countdown> { !$0.isArchived },
@@ -63,7 +64,7 @@ struct CountdownListView: View {
             .fullScreenCover(isPresented: $showPaywall, content: paywallSheet)
             .sheet(isPresented: $showSettingsPage) {
                 SettingsView()
-                    .environmentObject(themeManager)
+                    .environmentObject(themeSettings)
             }
             .fullScreenCover(isPresented: $showingBlankDetail) {
                 blankDetailOverlay(isPresented: $showingBlankDetail, onClose: { showingBlankDetail = false })
@@ -82,7 +83,6 @@ struct CountdownListView: View {
 
     private func addEditSheet() -> some View {
         AddEditCountdownView(existing: editing)
-            .environmentObject(themeManager)
             .environmentObject(pro)
     }
 

--- a/CouplesCount/Views/Settings/SettingsComponents.swift
+++ b/CouplesCount/Views/Settings/SettingsComponents.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // A soft, modern card container we can reuse
 struct SettingsCard<Content: View>: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     var content: () -> Content
 
     init(@ViewBuilder _ content: @escaping () -> Content) {
@@ -14,26 +14,26 @@ struct SettingsCard<Content: View>: View {
             .padding(16)
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(theme.theme.background)
+                    .fill(theme.color(.Card))
                     .overlay(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(Color.black, lineWidth: 1)
+                            .stroke(theme.color(.Border), lineWidth: 1)
                     )
             )
-            .shadow(color: theme.theme.textPrimary.opacity(0.12), radius: 12, y: 6)
+            .shadow(color: theme.color(.Foreground).opacity(0.12), radius: 12, y: 6)
             .padding(.horizontal, 16)
     }
 }
 
 // Section label that floats above the card
 struct SectionHeader: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     let text: String
     var body: some View {
         HStack {
             Text(text.uppercased())
                 .font(.footnote.weight(.semibold))
-                .foregroundStyle(theme.theme.textSecondary)
+                .foregroundStyle(theme.color(.MutedForeground))
             Spacer()
         }
         .padding(.horizontal, 16)
@@ -109,7 +109,7 @@ struct ThemeSwatch: View {
 }
 
 struct SettingsButtonRow: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     let icon: String
     let title: String
     let action: () -> Void
@@ -122,16 +122,16 @@ struct SettingsButtonRow: View {
             HStack(spacing: 12) {
                 Image(systemName: icon)
                     .font(.title3)
-                    .foregroundStyle(theme.theme.textPrimary)
+                    .foregroundStyle(theme.color(.Foreground))
                     .frame(width: 30, height: 30)
                     .background(
                         RoundedRectangle(cornerRadius: 8)
-                            .fill(theme.theme.textPrimary.opacity(0.1))
+                            .fill(theme.color(.Foreground).opacity(0.1))
                     )
                     .accessibilityHidden(true)
                 Text(title)
                     .font(.body)
-                    .foregroundStyle(theme.theme.textPrimary)
+                    .foregroundStyle(theme.color(.Foreground))
                 Spacer()
             }
             .contentShape(Rectangle())
@@ -141,17 +141,17 @@ struct SettingsButtonRow: View {
 }
 
 struct SettingsKeyValueRow: View {
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
     let key: String
     let value: String
 
     var body: some View {
         HStack {
             Text(key)
-                .foregroundStyle(theme.theme.textPrimary)
+                .foregroundStyle(theme.color(.Foreground))
             Spacer()
             Text(value)
-                .foregroundStyle(theme.theme.textSecondary)
+                .foregroundStyle(theme.color(.MutedForeground))
         }
         .font(.body)
     }

--- a/CouplesCount/Views/Settings/SettingsView.swift
+++ b/CouplesCount/Views/Settings/SettingsView.swift
@@ -3,7 +3,9 @@ import SwiftData
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var theme: ThemeManager
+    @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var themeSettings: ThemeSettings
     @Query(filter: #Predicate<Countdown> { $0.isArchived })
     private var archivedItems: [Countdown]
 
@@ -25,18 +27,17 @@ struct SettingsView: View {
                 }
                 .padding(.vertical, 20)
             }
-            .background(theme.theme.background.ignoresSafeArea())
-            .tint(theme.theme.textPrimary)
+            .background(theme.color(.Background).ignoresSafeArea())
+            .tint(theme.color(.Primary))
             .scrollIndicators(.hidden)
             .navigationTitle("Settings")
-            .toolbarColorScheme(theme.theme == .light ? .light : .dark, for: .navigationBar)
+            .toolbarColorScheme(themeSettings.selection.colorScheme ?? colorScheme, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
             }
         }
         .fullScreenCover(isPresented: $showPaywall) {
             PaywallView()
-                .environmentObject(theme)
         }
     }
 }
@@ -48,21 +49,21 @@ private extension SettingsView {
                 HStack(spacing: 12) {
                     Image(systemName: "paintpalette.fill")
                         .font(.title3)
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                         .frame(width: 30, height: 30)
                         .background(
                             RoundedRectangle(cornerRadius: 8)
-                                .fill(theme.theme.textPrimary.opacity(0.1))
+                                .fill(theme.color(.Foreground).opacity(0.1))
                         )
                         .accessibilityHidden(true)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Appearance")
                             .font(.body)
-                            .foregroundStyle(theme.theme.textPrimary)
+                            .foregroundStyle(theme.color(.Foreground))
                         Text("Choose your preferred theme")
                             .font(.footnote)
-                            .foregroundStyle(theme.theme.textSecondary)
+                            .foregroundStyle(theme.color(.MutedForeground))
                     }
 
                     Spacer()
@@ -71,12 +72,13 @@ private extension SettingsView {
                 Picker(
                     "Appearance",
                     selection: Binding(
-                        get: { theme.theme },
-                        set: { theme.setTheme($0) }
+                        get: { themeSettings.selection },
+                        set: { themeSettings.set($0) }
                     )
                 ) {
-                    Text("Light").tag(ColorTheme.light)
-                    Text("Dark").tag(ColorTheme.dark)
+                    Text("System").tag(AppTheme.system)
+                    Text("Light").tag(AppTheme.light)
+                    Text("Dark").tag(AppTheme.dark)
                 }
                 .pickerStyle(.segmented)
             }
@@ -89,28 +91,28 @@ private extension SettingsView {
                 HStack(spacing: 12) {
                     Image(systemName: "crown.fill")
                         .font(.title3)
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                         .frame(width: 30, height: 30)
                         .background(
                             RoundedRectangle(cornerRadius: 8)
-                                .fill(theme.theme.textPrimary.opacity(0.1))
+                                .fill(theme.color(.Foreground).opacity(0.1))
                         )
                         .accessibilityHidden(true)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Premium")
                             .font(.body)
-                            .foregroundStyle(theme.theme.textPrimary)
+                            .foregroundStyle(theme.color(.Foreground))
                         Text("Unlock unlimited countdowns and features")
                             .font(.footnote)
-                            .foregroundStyle(theme.theme.textSecondary)
+                            .foregroundStyle(theme.color(.MutedForeground))
                     }
 
                     Spacer()
 
                     Image(systemName: "chevron.right")
                         .font(.footnote.weight(.semibold))
-                        .foregroundStyle(theme.theme.textSecondary)
+                        .foregroundStyle(theme.color(.MutedForeground))
                 }
                 .contentShape(Rectangle())
             }
@@ -122,33 +124,32 @@ private extension SettingsView {
         SettingsCard {
             NavigationLink {
                 ArchiveView()
-                    .environmentObject(theme)
             } label: {
                 HStack(spacing: 12) {
                     Image(systemName: "archivebox.fill")
                         .font(.title3)
-                        .foregroundStyle(theme.theme.textPrimary)
+                        .foregroundStyle(theme.color(.Foreground))
                         .frame(width: 30, height: 30)
                         .background(
                             RoundedRectangle(cornerRadius: 8)
-                                .fill(theme.theme.textPrimary.opacity(0.1))
+                                .fill(theme.color(.Foreground).opacity(0.1))
                         )
                         .accessibilityHidden(true)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Archive")
                             .font(.body)
-                            .foregroundStyle(theme.theme.textPrimary)
+                            .foregroundStyle(theme.color(.Foreground))
                         Text("\(archivedItems.count) completed countdowns")
                             .font(.footnote)
-                            .foregroundStyle(theme.theme.textSecondary)
+                            .foregroundStyle(theme.color(.MutedForeground))
                     }
 
                     Spacer()
 
                     Image(systemName: "chevron.right")
                         .font(.footnote.weight(.semibold))
-                        .foregroundStyle(theme.theme.textSecondary)
+                        .foregroundStyle(theme.color(.MutedForeground))
                 }
                 .contentShape(Rectangle())
             }
@@ -160,13 +161,13 @@ private extension SettingsView {
         VStack(spacing: 4) {
             Text("Countdowns")
                 .font(.footnote.weight(.semibold))
-                .foregroundStyle(theme.theme.textSecondary)
+                .foregroundStyle(theme.color(.MutedForeground))
             Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")")
                 .font(.footnote)
-                .foregroundStyle(theme.theme.textSecondary)
+                .foregroundStyle(theme.color(.MutedForeground))
             Text("Made with ❤️ for shared moments")
                 .font(.footnote)
-                .foregroundStyle(theme.theme.textSecondary)
+                .foregroundStyle(theme.color(.MutedForeground))
         }
         .padding(.top, 12)
     }

--- a/Shared/Theme/ThemeSettings.swift
+++ b/Shared/Theme/ThemeSettings.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// Represents the app-wide appearance mode.
+enum AppTheme: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    /// Optional ColorScheme corresponding to the theme.
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system:
+            return nil
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+}
+
+/// Stores and publishes the current `AppTheme` selection.
+@MainActor
+final class ThemeSettings: ObservableObject {
+    @AppStorage("app_theme_selection") private var stored = AppTheme.system.rawValue
+    @Published var selection: AppTheme
+
+    init() {
+        selection = AppTheme(rawValue: stored) ?? .system
+    }
+
+    func set(_ newValue: AppTheme) {
+        selection = newValue
+        stored = newValue.rawValue
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `ThemeSettings` to persist system/light/dark selection
- update app to inject theme selection environment-wide
- migrate settings and add/edit screens to theme semantic colors

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af978c29c88333a0d8c70a8593cddc