### PR TITLE
Unify app on Premium light theme

### DIFF
--- a/CouplesCount/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/CouplesCount/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,7 +1,16 @@
 {
   "colors" : [
     {
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "green" : "0.650",
+          "blue" : "0.000",
+          "alpha" : "1.000"
+        }
+      }
     }
   ],
   "info" : {

--- a/CouplesCount/ContentView.swift
+++ b/CouplesCount/ContentView.swift
@@ -7,7 +7,7 @@ struct ContentView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [Color("Background"), Color("Primary")], startPoint: .top, endPoint: .bottom)
+            Theme.backgroundGradient
                 .ignoresSafeArea()
 
             TabView {
@@ -21,7 +21,7 @@ struct ContentView: View {
                         Label("Profile", systemImage: "person.crop.circle")
                     }
             }
-            .tint(Color("Primary"))
+            .tint(Theme.accent)
             .onOpenURL { url in
                 do {
                     try CountdownShareService.importCountdown(from: url, context: modelContext)

--- a/CouplesCount/Theme.swift
+++ b/CouplesCount/Theme.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+enum Theme {
+    static let backgroundTop = Color(red: 1.0, green: 0.95, blue: 0.92)
+    static let backgroundBottom = Color(red: 1.0, green: 0.90, blue: 0.85)
+    static let backgroundGradient = LinearGradient(
+        colors: [backgroundTop, backgroundBottom],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+    static let accent = Color.orange
+}

--- a/CouplesCount/Views/BlankDetailView.swift
+++ b/CouplesCount/Views/BlankDetailView.swift
@@ -5,7 +5,7 @@ struct BlankDetailView: View {
 
     var body: some View {
         ZStack {
-            Color("Background")
+            Theme.backgroundGradient
                 .ignoresSafeArea()
             Text("Detail (blank)")
                 .font(.title2)

--- a/CouplesCount/Views/Countdowns/AddEdit/AddEditCountdownView.swift
+++ b/CouplesCount/Views/Countdowns/AddEdit/AddEditCountdownView.swift
@@ -134,11 +134,11 @@ struct AddEditCountdownView: View {
                     .padding(.vertical, 8)
                     .padding(.trailing, 2)
             }
-            .background(Color("Background").ignoresSafeArea())
-            .tint(Color("Primary"))
+            .background(Theme.backgroundGradient.ignoresSafeArea())
+            .tint(Theme.accent)
             .navigationTitle(existing == nil ? "Add Countdown" : "Edit Countdown")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(Color("Background"), for: .navigationBar)
+            .toolbarBackground(Theme.backgroundTop, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -196,7 +196,7 @@ struct AddEditCountdownView: View {
                 if new != nil { Haptics.light() }
             }
             .onAppear {
-                let defaultHex = Color("Primary").hexString
+                let defaultHex = Theme.accent.hexString
                 if let existing {
                     title = existing.title
                     date = existing.targetDate
@@ -227,7 +227,7 @@ struct AddEditCountdownView: View {
                 }
             }
         }
-        .tint(Color("Primary"))
+        .tint(Theme.accent)
         .alert("Couldn’t Save",
                isPresented: Binding(get: { saveError != nil },
                                    set: { if !$0 { saveError = nil } })) {
@@ -244,7 +244,7 @@ struct AddEditCountdownView: View {
         guard !trimmed.isEmpty else { showValidation = true; return }
 
         do {
-            let defaultHex = Color("Primary").hexString.uppercased()
+            let defaultHex = Theme.accent.hexString.uppercased()
             let chosenHex = colorHex.uppercased()
             let storedHex: String? = (chosenHex == defaultHex) ? nil : chosenHex
 

--- a/CouplesCount/Views/Countdowns/AddEdit/ReminderPickerSection.swift
+++ b/CouplesCount/Views/Countdowns/AddEdit/ReminderPickerSection.swift
@@ -102,11 +102,11 @@ struct ReminderPicker: View {
                 }
                 .padding()
             }
-            .background(Color("Background").ignoresSafeArea())
-            .tint(Color("Primary"))
+            .background(Theme.backgroundGradient.ignoresSafeArea())
+            .tint(Theme.accent)
             .navigationTitle("Reminders")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(Color("Background"), for: .navigationBar)
+            .toolbarBackground(Theme.backgroundTop, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .principal) {

--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -23,7 +23,7 @@ struct CountdownListView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color("Background").ignoresSafeArea()
+                Theme.backgroundGradient.ignoresSafeArea()
 
                 VStack(spacing: 0) {
                     HeaderView(showPaywall: $showPaywall, showSettingsPage: $showSettingsPage)
@@ -66,7 +66,7 @@ struct CountdownListView: View {
                 blankDetailOverlay(isPresented: $showingBlankDetail, onClose: { showingBlankDetail = false })
             }
         }
-        .tint(Color("Primary"))
+        .tint(Theme.accent)
     }
 
     // MARK: - Overlays & Sheets
@@ -159,8 +159,8 @@ private struct AddButton: View {
                 Image(systemName: "plus")
                     .font(.title)
                     .padding(20)
-                    .background(Circle().fill(Color("Primary")))
-                    .foregroundStyle(Color("Background"))
+                    .background(Circle().fill(Theme.accent))
+                    .foregroundStyle(.white)
                     .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
                     .frame(minWidth: 44, minHeight: 44)
                     .contentShape(Rectangle())

--- a/CouplesCount/Views/Countdowns/CountdownRowActions.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowActions.swift
@@ -8,7 +8,7 @@ func DeleteSwipeButton(
     hint: String = "Remove countdown",
     iconOnly: Bool = true,
     background: Color = Color("Destructive"),
-    foreground: Color = Color("Background")
+    foreground: Color = .white
 ) -> some View {
     Button(role: .destructive, action: action) {
         if iconOnly {
@@ -34,8 +34,8 @@ func ArchiveSwipeButton(
     systemImage: String = "archivebox",
     hint: String = "Archive countdown",
     iconOnly: Bool = true,
-    background: Color = Color("Primary"),
-    foreground: Color = Color("Background")
+    background: Color = Theme.accent,
+    foreground: Color = .white
 ) -> some View {
     Button(action: action) {
         if iconOnly {
@@ -60,8 +60,8 @@ func ShareSwipeButton(
     label: String = "Share",
     hint: String = "Share countdown",
     iconOnly: Bool = true,
-    background: Color = Color("Accent"),
-    foreground: Color = Color("Background")
+    background: Color = Theme.accent,
+    foreground: Color = .white
 ) -> some View {
     Button(action: action) {
         if iconOnly {

--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -46,9 +46,9 @@ struct CountdownRowView: View {
         }
         .listRowSeparator(.hidden)
         .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
-        .listRowBackground(Color("Background"))
+        .listRowBackground(Color.white)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            DeleteSwipeButton({ onDelete(countdown) }, background: Color("Destructive"), foreground: Color("Background"))
+            DeleteSwipeButton({ onDelete(countdown) }, background: Color("Destructive"), foreground: .white)
         }
         .swipeActions(edge: .leading, allowsFullSwipe: false) {
             ArchiveSwipeButton(
@@ -56,8 +56,8 @@ struct CountdownRowView: View {
                 label: countdown.isArchived ? "Unarchive" : "Archive",
                 systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox",
                 hint: countdown.isArchived ? "Restore countdown" : "Archive countdown",
-                background: Color("Primary"),
-                foreground: Color("Background")
+                background: Theme.accent,
+                foreground: .white
             )
         }
     }

--- a/CouplesCount/Views/FeedbackFormView.swift
+++ b/CouplesCount/Views/FeedbackFormView.swift
@@ -39,7 +39,7 @@ struct FeedbackFormView: View {
                 .frame(maxWidth: .infinity)
                 .controlSize(.large)
                 .buttonStyle(.borderedProminent)
-                .tint(Color("Primary"))
+                .tint(Theme.accent)
             }
             .padding()
             .navigationTitle("Feedback")
@@ -50,7 +50,8 @@ struct FeedbackFormView: View {
                 }
             }
         }
-        .tint(Color("Foreground"))
+        .background(Theme.backgroundGradient.ignoresSafeArea())
+        .tint(Theme.accent)
     }
 }
 

--- a/CouplesCount/Views/OnboardingView.swift
+++ b/CouplesCount/Views/OnboardingView.swift
@@ -12,8 +12,8 @@ struct OnboardingView: View {
             finalSlide
         }
         .tabViewStyle(.page)
-        .background(Color("Background").ignoresSafeArea())
-        .tint(Color("Primary"))
+        .background(Theme.backgroundGradient.ignoresSafeArea())
+        .tint(Theme.accent)
     }
 
     @ViewBuilder
@@ -55,10 +55,10 @@ struct OnboardingView: View {
             Button(action: finishOnboarding) {
                 Text("Done")
                     .font(.headline)
-                    .foregroundStyle(Color("Background"))
+                    .foregroundStyle(.white)
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(RoundedRectangle(cornerRadius: 12).fill(Color("Primary")))
+                    .background(RoundedRectangle(cornerRadius: 12).fill(Theme.accent))
             }
             .padding(.top, 32)
             .padding(.horizontal)

--- a/CouplesCount/Views/PlaceholderPageView.swift
+++ b/CouplesCount/Views/PlaceholderPageView.swift
@@ -5,7 +5,7 @@ struct PlaceholderPageView: View {
 
     var body: some View {
         ZStack {
-            Color("Background")
+            Theme.backgroundGradient
                 .ignoresSafeArea()
         }
         .navigationTitle(title)

--- a/CouplesCount/Views/PremiumPromoView.swift
+++ b/CouplesCount/Views/PremiumPromoView.swift
@@ -6,7 +6,7 @@ struct PremiumPromoView: View {
 
     var body: some View {
         ZStack {
-            Color("Background").ignoresSafeArea()
+            Theme.backgroundGradient.ignoresSafeArea()
 
             VStack {
                 Spacer()
@@ -24,7 +24,7 @@ struct PremiumPromoView: View {
                 Spacer()
             }
         }
-        .tint(Color("Foreground"))
+        .tint(Theme.accent)
         .safeAreaInset(edge: .top, alignment: .leading) {
             Button {
                 withAnimation(.spring()) { show = false }

--- a/CouplesCount/Views/ProfileView.swift
+++ b/CouplesCount/Views/ProfileView.swift
@@ -128,7 +128,7 @@ struct ProfileView: View {
                                     updateWidgetSnapshot(afterSaving: all)
                                 }
                                 Haptics.warning()
-                            }, iconOnly: false, background: Color("Destructive"), foreground: Color("Background"))
+                            }, iconOnly: false, background: Color("Destructive"), foreground: .white)
 
                             ArchiveSwipeButton({
                                 withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
@@ -138,7 +138,7 @@ struct ProfileView: View {
                                     updateWidgetSnapshot(afterSaving: all)
                                 }
                                 Haptics.light()
-                            }, iconOnly: false, background: Color("Primary"), foreground: Color("Background"))
+                            }, iconOnly: false, background: Theme.accent, foreground: .white)
                         }
                     }
                 }
@@ -147,6 +147,6 @@ struct ProfileView: View {
                 .animation(.spring(response: 0.4, dampingFraction: 0.85), value: shared)
             }
         }
-        .background(Color("Background").ignoresSafeArea())
+        .background(Theme.backgroundGradient.ignoresSafeArea())
     }
 }

--- a/CouplesCount/Views/Settings/ArchiveView.swift
+++ b/CouplesCount/Views/Settings/ArchiveView.swift
@@ -11,7 +11,7 @@ struct ArchiveView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color("Background").ignoresSafeArea()
+                Theme.backgroundGradient.ignoresSafeArea()
 
                 if items.isEmpty {
                     VStack(spacing: 8) {
@@ -51,7 +51,7 @@ struct ArchiveView: View {
                                         Haptics.warning()
                                     },
                                     background: Color("Destructive"),
-                                    foreground: Color("Background")
+                                    foreground: .white
                                 )
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: false) {
@@ -67,8 +67,8 @@ struct ArchiveView: View {
                                     label: "Unarchive",
                                     systemImage: "arrow.uturn.backward",
                                     hint: "Restore countdown",
-                                    background: Color("Primary"),
-                                    foreground: Color("Background")
+                                    background: Theme.accent,
+                                    foreground: .white
                                 )
                             }
                         }
@@ -86,7 +86,7 @@ struct ArchiveView: View {
                 }
             }
         }
-        .tint(Color("Foreground"))
+        .tint(Theme.accent)
     }
 }
 

--- a/CouplesCount/Views/Settings/SettingsComponents.swift
+++ b/CouplesCount/Views/Settings/SettingsComponents.swift
@@ -13,13 +13,13 @@ struct SettingsCard<Content: View>: View {
             .padding(16)
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(Color("Background"))
+                    .fill(Color.white)
                     .overlay(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(Color("Border"), lineWidth: 1)
+                            .stroke(Color.black.opacity(0.1), lineWidth: 1)
                     )
             )
-            .shadow(color: Color("Foreground").opacity(0.12), radius: 12, y: 6)
+            .shadow(color: Color.black.opacity(0.12), radius: 12, y: 6)
             .padding(.horizontal, 16)
     }
 }

--- a/CouplesCount/Views/Settings/SettingsView.swift
+++ b/CouplesCount/Views/Settings/SettingsView.swift
@@ -22,8 +22,8 @@ struct SettingsView: View {
                 }
                 .padding(.vertical, 20)
             }
-            .background(Color("Background").ignoresSafeArea())
-            .tint(Color("Primary"))
+            .background(Theme.backgroundGradient.ignoresSafeArea())
+            .tint(Theme.accent)
             .scrollIndicators(.hidden)
             .navigationTitle("Settings")
             .toolbar {

--- a/CouplesCountWidget/CouplesCountComplication.swift
+++ b/CouplesCountWidget/CouplesCountComplication.swift
@@ -1,0 +1,91 @@
+import WidgetKit
+import SwiftUI
+import AppIntents
+
+/// Timeline entry for the watch complication widget.
+struct CouplesCountComplicationEntry: TimelineEntry {
+    let date: Date
+    let entity: CountdownEntity
+}
+
+/// Provider for the watch complication that refreshes once per day.
+struct CouplesCountComplicationProvider: AppIntentTimelineProvider {
+    typealias Entry = CouplesCountComplicationEntry
+    typealias Intent = SelectCountdown
+
+    func placeholder(in context: Context) -> Entry {
+        .init(date: .now, entity: .preview)
+    }
+
+    func snapshot(for configuration: SelectCountdown, in context: Context) async -> Entry {
+        let chosen = configuration.countdown ?? .preview
+        return .init(date: .now, entity: chosen)
+    }
+
+    func timeline(for configuration: SelectCountdown, in context: Context) async -> Timeline<Entry> {
+        let chosen = configuration.countdown ?? .preview
+        let midnight = Calendar.current.nextDate(
+            after: .now,
+            matching: DateComponents(hour: 0, minute: 1),
+            matchingPolicy: .nextTime
+        ) ?? .now.addingTimeInterval(86_400)
+        return Timeline(entries: [.init(date: .now, entity: chosen)], policy: .after(midnight))
+    }
+}
+
+/// View shown in the watch complication families.
+struct CouplesCountComplicationView: View {
+    var entry: CouplesCountComplicationEntry
+
+    private var cardColor: Color {
+        resolvedCardColor(backgroundStyle: "color", colorHex: nil)
+    }
+
+    private var primaryText: Color { cardColor.readablePrimary }
+    private var secondaryText: Color { cardColor.readableSecondary }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(entry.entity.title)
+                .font(CardTypography.font(for: entry.entity.cardFontStyle, role: .title))
+                .foregroundStyle(primaryText)
+                .lineLimit(1)
+
+            Text(DateUtils.remainingText(to: entry.entity.targetDate, from: entry.date, in: entry.entity.timeZoneID))
+                .font(CardTypography.font(for: entry.entity.cardFontStyle, role: .number))
+                .foregroundStyle(primaryText)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(
+            AnyShapeStyle(cardColor),
+            for: .widget
+        )
+    }
+}
+
+/// Watch complication widget configuration.
+struct CouplesCountComplication: Widget {
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: "CouplesCountComplication",
+            intent: SelectCountdown.self,
+            provider: CouplesCountComplicationProvider()
+        ) { entry in
+            CouplesCountComplicationView(entry: entry)
+        }
+        .configurationDisplayName("Countdown")
+        .description("Shows a selected countdown.")
+        .supportedFamilies([
+            .accessoryCircular,
+            .accessoryInline,
+            .accessoryRectangular
+        ])
+    }
+}
+
+#Preview(as: .accessoryCircular) {
+    CouplesCountComplication()
+} timeline: {
+    CouplesCountComplicationEntry(date: .now, entity: .preview)
+}
+

--- a/CouplesCountWidget/CouplesCountWidgetBundle.swift
+++ b/CouplesCountWidget/CouplesCountWidgetBundle.swift
@@ -5,5 +5,6 @@ import SwiftUI
 struct CouplesCountWidgetBundle: WidgetBundle {
     var body: some Widget {
         CouplesCountWidget()
+        CouplesCountComplication()
     }
 }

--- a/Shared/Colors.xcassets/Accent.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Accent.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.914",
-          "green": "0.922",
-          "blue": "0.937",
+          "red": "1.000",
+          "green": "0.650",
+          "blue": "0.000",
           "alpha": "1.000"
         }
       }
@@ -16,6 +16,6 @@
   "info": {
     "version": 1,
     "author": "xcode",
-    "light": "light:#e9ebef"
+    "light": "light:#ffa500"
   }
 }

--- a/Shared/Colors.xcassets/Background.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Background.colorset/Contents.json
@@ -6,8 +6,8 @@
         "color-space": "srgb",
         "components": {
           "red": "1.000",
-          "green": "1.000",
-          "blue": "1.000",
+          "green": "0.950",
+          "blue": "0.920",
           "alpha": "1.000"
         }
       }
@@ -16,6 +16,6 @@
   "info": {
     "version": 1,
     "author": "xcode",
-    "light": "light:#ffffff"
+    "light": "light:#fff2eb"
   }
 }

--- a/Shared/Colors.xcassets/Foreground.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Foreground.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.039",
-          "green": "0.039",
-          "blue": "0.039",
+          "red": "0.000",
+          "green": "0.000",
+          "blue": "0.000",
           "alpha": "1.000"
         }
       }
@@ -16,6 +16,6 @@
   "info": {
     "version": 1,
     "author": "xcode",
-    "light": "light:oklch(0.145 0 0)"
+    "light": "light:#000000"
   }
 }

--- a/Shared/Colors.xcassets/Primary.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Primary.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.012",
-          "green": "0.008",
-          "blue": "0.075",
+          "red": "1.000",
+          "green": "0.650",
+          "blue": "0.000",
           "alpha": "1.000"
         }
       }
@@ -16,6 +16,6 @@
   "info": {
     "version": 1,
     "author": "xcode",
-    "light": "light:#030213"
+    "light": "light:#ffa500"
   }
 }

--- a/Shared/Colors.xcassets/Secondary.colorset/Contents.json
+++ b/Shared/Colors.xcassets/Secondary.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.925",
-          "green": "0.933",
-          "blue": "0.949",
+          "red": "0.400",
+          "green": "0.400",
+          "blue": "0.400",
           "alpha": "1.000"
         }
       }
@@ -16,6 +16,6 @@
   "info": {
     "version": 1,
     "author": "xcode",
-    "light": "light:oklch(0.95 0.0058 264.53)"
+    "light": "light:#666666"
   }
 }


### PR DESCRIPTION
## Summary
- Introduce shared `Theme` with Premium-inspired gradient and accent color
- Apply Premium gradient and orange accent to settings, add/edit countdown, list, and other screens
- Refresh global color assets for a consistent light-mode palette
- Add watch complication widget using the modern `AppIntentTimelineProvider`

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68afa31cbd588333abbb4b88c1e4fdba