### PR TITLE
Add theme picker in settings

### DIFF
--- a/CouplesCount/Appearance.swift
+++ b/CouplesCount/Appearance.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+enum Appearance: String, CaseIterable, Identifiable {
+    case light
+    case dark
+
+    var id: Self { self }
+
+    var colorScheme: ColorScheme {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}

--- a/CouplesCount/CouplesCountApp.swift
+++ b/CouplesCount/CouplesCountApp.swift
@@ -6,6 +6,7 @@ struct CouplesCountApp: App {
     @StateObject private var pro: ProStatusProvider
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     @State private var showDeniedInfo = false
+    @AppStorage("appearance") private var appearance: Appearance = .light
 
     init() {
         let provider = ProStatusProvider()
@@ -41,7 +42,7 @@ struct CouplesCountApp: App {
                 .padding()
                 .presentationDetents([.medium])
             }
-            .preferredColorScheme(.light)
+            .preferredColorScheme(appearance.colorScheme)
         }
     }
 }

--- a/CouplesCount/Views/Settings/SettingsView.swift
+++ b/CouplesCount/Views/Settings/SettingsView.swift
@@ -6,12 +6,15 @@ struct SettingsView: View {
     @Query(filter: #Predicate<Countdown> { $0.isArchived })
     private var archivedItems: [Countdown]
 
+    @AppStorage("appearance") private var appearance: Appearance = .light
     @State private var showPaywall = false
 
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 18) {
+                    appearanceSection
+
                     if AppConfig.entitlementsMode == .live && !Entitlements.current.isUnlimited {
                         premiumSection
                     }
@@ -30,6 +33,7 @@ struct SettingsView: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
             }
         }
+        .preferredColorScheme(appearance.colorScheme)
         .fullScreenCover(isPresented: $showPaywall) {
             PaywallView()
         }
@@ -37,6 +41,37 @@ struct SettingsView: View {
 }
 
 private extension SettingsView {
+    var appearanceSection: some View {
+        SettingsCard {
+            HStack(spacing: 12) {
+                Image(systemName: "paintpalette.fill")
+                    .font(.title3)
+                    .foregroundStyle(Color("Foreground"))
+                    .frame(width: 30, height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color("Foreground").opacity(0.1))
+                    )
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Appearance")
+                        .font(.body)
+                        .foregroundStyle(Color("Foreground"))
+                    Text("Choose your preferred theme")
+                        .font(.footnote)
+                        .foregroundStyle(Color("Secondary"))
+
+                    Picker("Appearance", selection: $appearance) {
+                        Text("Light").tag(Appearance.light)
+                        Text("Dark").tag(Appearance.dark)
+                    }
+                    .pickerStyle(.segmented)
+                }
+            }
+        }
+    }
+
     var premiumSection: some View {
         SettingsCard {
             Button(action: { showPaywall = true }) {


### PR DESCRIPTION
## Summary
- allow choosing light or dark mode in Settings
- persist appearance using AppStorage
- apply selected appearance across the app

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68afa34dbe1c833393a0e0181449ff21