### PR TITLE
Use monospaced digits for countdown numbers

### DIFF
--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -144,6 +144,7 @@ struct CountdownCardView: View {
                 VStack(alignment: .center, spacing: 4) {
                     Text(remaining.value)
                         .font(CardTypography.font(for: fontStyle, role: .number))
+                        .monospacedDigit()
                         .foregroundStyle(primaryText)
 
                     Text(remaining.unit)

--- a/Shared/Utilities/CardTypography.swift
+++ b/Shared/Utilities/CardTypography.swift
@@ -10,7 +10,8 @@ struct CardTypography {
 
     /// SwiftUI font for a given style and role.
     static func font(for style: CardFontStyle, role: Role) -> Font {
-        Font(uiFont(for: style, role: role))
+        let font = Font(uiFont(for: style, role: role))
+        return role == .number ? font.monospacedDigit() : font
     }
 
     /// UIKit font for a given style and role.
@@ -18,7 +19,7 @@ struct CardTypography {
         let (textStyle, weight): (UIFont.TextStyle, UIFont.Weight) = {
             switch role {
             case .title: return (.headline, .semibold)
-            case .number: return (.largeTitle, .bold)
+            case .number: return (.largeTitle, .heavy)
             case .date: return (.footnote, .regular)
             }
         }()


### PR DESCRIPTION
## Summary
- Use monospaced digits when displaying countdown values
- Bump number font weight to heavy

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0345ffe908333afe4bd6abe42f118