### PR TITLE
Refine unit label styling in countdown card

### DIFF
--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -148,8 +148,13 @@ struct CountdownCardView: View {
                         .foregroundStyle(primaryText)
 
                     Text(remaining.unit)
-                        .font(.caption)
-                        .fontWeight(.semibold)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .font(.caption.bold())
+                        .tracking(1)
+                        .background(
+                            Capsule().stroke(primaryText)
+                        )
                         .foregroundStyle(primaryText)
                 }
             }


### PR DESCRIPTION
## Summary
- wrap countdown unit text in padded capsule
- use bold caption font with tracking for unit label

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0357b9db0833391b5cccff674bffa