### PR TITLE
Switch to tinted swipe actions

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -202,7 +202,6 @@ private struct CountdownListSection: View {
                             let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
                             updateWidgetSnapshot(afterSaving: all)
                         }
-                        Haptics.warning()
                     },
                     onArchiveToggle: { countdown in
                         withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
@@ -211,7 +210,6 @@ private struct CountdownListSection: View {
                             let all = (try? modelContext.fetch(FetchDescriptor<Countdown>())) ?? []
                             updateWidgetSnapshot(afterSaving: all)
                         }
-                        if countdown.isArchived { Haptics.light() }
                     },
                     onSelect: { countdown in
                         selectedCountdown = countdown

--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -12,6 +12,8 @@ struct CountdownRowView: View {
     let onSelect: (Countdown) -> Void
 
     @State private var isPressing = false
+    @State private var showTrailingActions = false
+    @State private var showLeadingActions = false
 
     var body: some View {
         let dateText = DateUtils.readableDate.string(from: countdown.targetDate)
@@ -48,17 +50,31 @@ struct CountdownRowView: View {
         .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
         .listRowBackground(Color.white)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            DeleteSwipeButton({ onDelete(countdown) }, background: Color("Destructive"), foreground: .white)
+            Button(role: .destructive) {
+                onDelete(countdown)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            .tint(Color("Destructive"))
+            .onAppear { showTrailingActions = true }
+            .onDisappear { showTrailingActions = false }
         }
         .swipeActions(edge: .leading, allowsFullSwipe: false) {
-            ArchiveSwipeButton(
-                { onArchiveToggle(countdown) },
-                label: countdown.isArchived ? "Unarchive" : "Archive",
-                systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox",
-                hint: countdown.isArchived ? "Restore countdown" : "Archive countdown",
-                background: Theme.accent,
-                foreground: .white
-            )
+            Button {
+                onArchiveToggle(countdown)
+            } label: {
+                Label(countdown.isArchived ? "Unarchive" : "Archive",
+                      systemImage: countdown.isArchived ? "arrow.uturn.backward" : "archivebox")
+            }
+            .tint(Theme.accent)
+            .onAppear { showLeadingActions = true }
+            .onDisappear { showLeadingActions = false }
+        }
+        .onChange(of: showTrailingActions, initial: false) { _, newValue in
+            if newValue { Haptics.light() }
+        }
+        .onChange(of: showLeadingActions, initial: false) { _, newValue in
+            if newValue { Haptics.light() }
         }
     }
 }


### PR DESCRIPTION
## Summary
- use full-width tinted swipe actions instead of circular buttons
- add haptic feedback when swipe actions are revealed
- streamline delete/archive handlers

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b036ec20f4833398f6d055123d265f