### PR TITLE
Improve countdown row press feedback

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -11,7 +11,7 @@ struct CountdownRowView: View {
     let onArchiveToggle: (Countdown) -> Void
     let onSelect: (Countdown) -> Void
 
-    @State private var isPressing = false
+    @State private var isPressed = false
 
     var body: some View {
         let dateText = DateUtils.readableDate.string(from: countdown.targetDate)
@@ -33,12 +33,16 @@ struct CountdownRowView: View {
             }
         )
         .contentShape(Rectangle())
-        .onTapGesture { onSelect(countdown) }
-        .scaleEffect(isPressing ? 0.97 : 1)
-        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isPressing)
+        .onTapGesture {
+            Haptics.light()
+            onSelect(countdown)
+        }
+        .scaleEffect(isPressed ? 0.97 : 1)
+        .shadow(radius: isPressed ? 0 : 4)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isPressed)
         .onLongPressGesture(minimumDuration: 0.4, maximumDistance: 50, pressing: { pressing in
             withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                isPressing = pressing
+                isPressed = pressing
             }
         }) {
             Haptics.light()


### PR DESCRIPTION
## Summary
- animate countdown row press with scale and shadow
- add light haptic feedback before selecting a countdown

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b0382e1f608333bad966ea765d8103