### PR TITLE
Refine countdown row insets and card padding

### DIFF
--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -148,8 +148,8 @@ struct CountdownCardView: View {
                         .foregroundStyle(primaryText)
 
                     Text(remaining.unit)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
                         .font(.caption.bold())
                         .tracking(1)
                         .background(

--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -49,7 +49,7 @@ struct CountdownRowView: View {
             onEdit(countdown)
         }
         .listRowSeparator(.hidden)
-        .listRowInsets(.init(top: 4, leading: 16, bottom: 4, trailing: 16))
+        .listRowInsets(.init(top: 8, leading: 16, bottom: 8, trailing: 16))
         .listRowBackground(Color.white)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             DeleteSwipeButton({ onDelete(countdown) }, background: Color("Destructive"), foreground: .white)


### PR DESCRIPTION
## Summary
- set list row insets to 8/16 in `CountdownRowView`
- use 4pt-multiple padding for unit badge in `CountdownCardView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b03aedbd8c83338fe38b3a36e986c3