### PR TITLE
Use transparent list row background in countdown row view

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -50,7 +50,7 @@ struct CountdownRowView: View {
         }
         .listRowSeparator(.hidden)
         .listRowInsets(.init(top: 8, leading: 16, bottom: 8, trailing: 16))
-        .listRowBackground(Color.white)
+        .listRowBackground(Color.clear)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             DeleteSwipeButton({ onDelete(countdown) }, background: Color("Destructive"), foreground: .white)
         }


### PR DESCRIPTION
## Summary
- Let the gradient background show by making CountdownRowView list rows clear

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b0413ae2ac8333a579fcbd5f382e0c