### PR TITLE
Use softer shadow for countdown row

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownRowView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownRowView.swift
@@ -38,7 +38,7 @@ struct CountdownRowView: View {
             onSelect(countdown)
         }
         .scaleEffect(isPressed ? 0.97 : 1)
-        .shadow(radius: isPressed ? 0 : 4)
+        .shadow(color: .black.opacity(0.05), radius: isPressed ? 0 : 4, y: 2)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isPressed)
         .onLongPressGesture(minimumDuration: 0.4, maximumDistance: 50, pressing: { pressing in
             withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {


### PR DESCRIPTION
## Summary
- soften countdown row shadow to avoid bloom on light backgrounds

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68b0425364a08333b313bb2fe489c712