### PR TITLE
docs: note view background and shadow updates

### DIFF
--- a/DevLog.md
+++ b/DevLog.md
@@ -1,0 +1,1 @@
+Removed the white list-row backing in `CountdownRowView`, softened card shadows, and confirmed that `CountdownListView` and `ContentView` continue using `Theme.backgroundGradient`.


### PR DESCRIPTION
## Summary
- log removal of list-row backing in `CountdownRowView`
- document softened card shadows
- note that `CountdownListView` and `ContentView` still use `Theme.backgroundGradient`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b04b0bfa6c833387c4590c8f1e5224