### PR TITLE
Hide navigation bar in countdown list

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -66,6 +66,7 @@ struct CountdownListView: View {
                 CountdownDetailView(countdown: countdown)
             }
         }
+        .toolbar(.hidden, for: .navigationBar)
         .tint(Theme.accent)
     }
 


### PR DESCRIPTION
## Summary
- Remove implicit navigation bar spacing in CountdownListView by hiding the navigation bar on its root NavigationStack.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d898a948333a2d44f78c724042f