### PR TITLE
Adjust header spacing in countdown list

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -27,6 +27,7 @@ struct CountdownListView: View {
 
                 VStack(spacing: 0) {
                     HeaderView(showPaywall: $showPaywall, showSettingsPage: $showSettingsPage)
+                        .ignoresSafeArea(edges: .top)
 
 
                     if items.isEmpty {
@@ -117,7 +118,6 @@ private struct HeaderView: View {
             }
         }
         .padding(.horizontal)
-        .padding(.top, 8)
         .padding(.bottom, 8)
         .background(Color.white)
         .shadow(color: .black.opacity(0.05), radius: 4, y: 2)


### PR DESCRIPTION
## Summary
- Remove extra top padding from header view
- Allow header to extend into top safe area

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0520348b48333ad72321083011791