### PR TITLE
Use shared NowProvider for countdown timing

### DIFF
--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -47,7 +47,7 @@ struct CountdownCardView: View {
 
 
     private let corner: CGFloat = 16
-    @State private var now = Date()
+    @EnvironmentObject private var nowProvider: NowProvider
 
     private var cardColor: Color {
         resolvedCardColor(backgroundStyle: backgroundStyle, colorHex: colorHex)
@@ -62,7 +62,7 @@ struct CountdownCardView: View {
     }
 
     private var remaining: (value: String, unit: String) {
-        let text = DateUtils.remainingText(to: targetDate, from: now, in: timeZoneID)
+        let text = DateUtils.remainingText(to: targetDate, from: nowProvider.now, in: timeZoneID)
         let parts = text.split(separator: " ")
         let value = parts.first.map(String.init) ?? ""
         let unit = parts.dropFirst().first.map { $0.uppercased() } ?? ""
@@ -196,8 +196,7 @@ struct CountdownCardView: View {
         .opacity(archived ? 0.55 : 1)
         .animation(.spring(response: 0.4, dampingFraction: 0.85), value: archived)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title), \(DateUtils.remainingText(to: targetDate, from: now, in: timeZoneID)), \(dateText)")
-        .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { now = $0 }
+        .accessibilityLabel("\(title), \(DateUtils.remainingText(to: targetDate, from: nowProvider.now, in: timeZoneID)), \(dateText)")
     }
 
     private var accentGradient: LinearGradient {

--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -4,6 +4,7 @@ import UIKit
 
 struct CountdownListView: View {
     @EnvironmentObject private var pro: ProStatusProvider
+    @StateObject private var nowProvider = NowProvider()
 
     @Query(filter: #Predicate<Countdown> { !$0.isArchived },
            sort: \.targetUTC, order: .forward)
@@ -68,6 +69,7 @@ struct CountdownListView: View {
         }
         .toolbar(.hidden, for: .navigationBar)
         .tint(Theme.accent)
+        .environmentObject(nowProvider)
     }
 
     private func addEditSheet() -> some View {

--- a/Shared/Utilities/NowProvider.swift
+++ b/Shared/Utilities/NowProvider.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Combine
+
+@MainActor
+final class NowProvider: ObservableObject {
+    @Published private(set) var now: Date = Date()
+    private var cancellable: AnyCancellable?
+
+    init() {
+        cancellable = Timer.publish(every: 60, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] date in
+                self?.now = date
+            }
+    }
+
+    deinit {
+        cancellable?.cancel()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NowProvider` observable object that publishes the current time each minute.
- Inject `NowProvider` into `CountdownCardView` and compute remaining time from shared provider.
- Instantiate `NowProvider` once in `CountdownListView` and pass it through the environment.

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b05a27bc0c8333a399287a18e93de6