### PR TITLE
Cache countdown time formatter

### DIFF
--- a/CouplesCount/Views/CountdownCardView.swift
+++ b/CouplesCount/Views/CountdownCardView.swift
@@ -69,12 +69,17 @@ struct CountdownCardView: View {
         return (value, unit)
     }
 
+    private static let timeFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateStyle = .none
+        df.timeStyle = .short
+        return df
+    }()
+
     private var timeText: String {
-        let tf = DateFormatter()
-        tf.dateStyle = .none
-        tf.timeStyle = .short
-        tf.timeZone = TimeZone(identifier: timeZoneID)
-        return tf.string(from: targetDate)
+        let formatter = Self.timeFormatter
+        formatter.timeZone = TimeZone(identifier: timeZoneID)
+        return formatter.string(from: targetDate)
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Cache a short-style DateFormatter for countdown card times
- Use the shared formatter and apply each card's time zone

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b05c1fb5848333926be07efc3dd0eb