### PR TITLE
Apply top padding to countdown list

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -217,6 +217,7 @@ private struct CountdownListSection: View {
         .listStyle(.plain)
         .listRowSpacing(16)
         .scrollContentBackground(.hidden)
+        .padding(.top, 16)
         .refreshable { await refreshAction?() }
         .animation(.spring(response: 0.4, dampingFraction: 0.85), value: items)
     }


### PR DESCRIPTION
## Summary
- Add top padding to countdown list for consistent spacing

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b065791d5c8333b47acb873715aaad