### PR TITLE
Reinstate navigation title and toolbar buttons

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -63,32 +63,32 @@ struct CountdownListView: View {
             .fullScreenCover(item: $selectedCountdown) { countdown in
                 CountdownDetailView(countdown: countdown)
             }
-        }
-        .navigationTitle("Countdowns")
-        .navigationBarTitleDisplayMode(.large)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button { showPaywall = true } label: {
-                    Image(systemName: "crown")
-                        .foregroundStyle(Color("Foreground"))
+            .navigationTitle("Countdowns")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button { showPaywall = true } label: {
+                        Image(systemName: "crown")
+                            .foregroundStyle(Color("Foreground"))
+                    }
                 }
-            }
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button { showSettingsPage = true } label: {
-                    Image(systemName: "gearshape")
-                        .foregroundStyle(Color("Foreground"))
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button { showSettingsPage = true } label: {
+                        Image(systemName: "gearshape")
+                            .foregroundStyle(Color("Foreground"))
+                    }
                 }
-            }
-            ToolbarItem(placement: .principal) {
-                VStack(spacing: 4) {
-                    Text("Countdowns")
-                        .font(.largeTitle.bold())
-                        .foregroundStyle(Color("Foreground"))
-                    Text("Shared moments with loved ones")
-                        .font(.subheadline)
-                        .foregroundStyle(Color("Secondary"))
+                ToolbarItem(placement: .principal) {
+                    VStack(spacing: 4) {
+                        Text("Countdowns")
+                            .font(.largeTitle.bold())
+                            .foregroundStyle(Color("Foreground"))
+                        Text("Shared moments with loved ones")
+                            .font(.subheadline)
+                            .foregroundStyle(Color("Secondary"))
+                    }
+                    .multilineTextAlignment(.center)
                 }
-                .multilineTextAlignment(.center)
             }
         }
         .tint(Theme.accent)


### PR DESCRIPTION
## Summary
- Move navigation title and toolbar modifiers inside `NavigationStack` so "Countdowns" title, Settings, and crown buttons render correctly

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b067656f888333aa3d6e724cbb2486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted navigation bar and toolbar layout in the countdown list view for consistency and readability.
  * Center title block formatting adjusted internally; icons, actions, and fonts unchanged.
  * No changes to behavior, data, or public interfaces; app experience remains the same.
  * No visual differences are expected across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->