### PR TITLE
Hide system navigation bar for countdown list

### DIFF
--- a/CouplesCount/Views/Countdowns/CountdownListView.swift
+++ b/CouplesCount/Views/Countdowns/CountdownListView.swift
@@ -63,16 +63,14 @@ struct CountdownListView: View {
             .fullScreenCover(item: $selectedCountdown) { countdown in
                 CountdownDetailView(countdown: countdown)
             }
-            .navigationTitle("Countdowns")
-            .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button { showPaywall = true } label: {
                         Image(systemName: "crown")
                             .foregroundStyle(Color("Foreground"))
                     }
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button { showSettingsPage = true } label: {
                         Image(systemName: "gearshape")
                             .foregroundStyle(Color("Foreground"))
@@ -91,6 +89,7 @@ struct CountdownListView: View {
                 }
             }
         }
+        .toolbar(.hidden, for: .navigationBar)
         .tint(Theme.accent)
         .environmentObject(nowProvider)
     }


### PR DESCRIPTION
## Summary
- Remove redundant navigation title from `CountdownListView`
- Hide the system navigation bar so only the custom header is visible
- Update toolbar item placements to `topBarLeading`/`topBarTrailing`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b07e9b647083339dd9e7a3b1857363