### PR TITLE
Add Diagnostics row to Settings for debug builds

### DIFF
--- a/CouplesCount/Views/Settings/SettingsView.swift
+++ b/CouplesCount/Views/Settings/SettingsView.swift
@@ -18,6 +18,10 @@ struct SettingsView: View {
 
                     archiveSection
 
+#if DEBUG
+                    diagnosticsSection
+#endif
+
                     footer
                 }
                 .padding(.vertical, 20)
@@ -140,6 +144,40 @@ private extension SettingsView {
             .buttonStyle(.plain)
         }
     }
+
+#if DEBUG
+    var diagnosticsSection: some View {
+        SettingsCard {
+            NavigationLink {
+                DiagnosticsView()
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "ladybug.fill")
+                        .font(.title3)
+                        .foregroundStyle(Color("Foreground"))
+                        .frame(width: 30, height: 30)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color("Foreground").opacity(0.1))
+                        )
+                        .accessibilityHidden(true)
+
+                    Text("Diagnostics")
+                        .font(.body)
+                        .foregroundStyle(Color("Foreground"))
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(Color("Secondary"))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+#endif
 
     var footer: some View {
         VStack(spacing: 4) {


### PR DESCRIPTION
## Summary
- Add a Diagnostics row in Settings that's only compiled for DEBUG builds
- Implement `diagnosticsSection` navigating to `DiagnosticsView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a33986408333ad44ba6dbe087da0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Diagnostics entry in Settings to access troubleshooting tools during development. The item matches existing settings styling and navigates to a dedicated diagnostics screen. This option is available only in development builds and is hidden in production, resulting in no user-facing changes for regular users. Improves developer troubleshooting without impacting the release experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->